### PR TITLE
Fix -l flag conflict between --log-level and --lines

### DIFF
--- a/cmd/tunnelmesh/service.go
+++ b/cmd/tunnelmesh/service.go
@@ -121,7 +121,7 @@ Log locations by platform:
 	}
 	logsCmd.Flags().StringVarP(&serviceName, "name", "n", "", "Service name")
 	logsCmd.Flags().BoolVarP(&logsFollow, "follow", "f", false, "Follow log output (like tail -f)")
-	logsCmd.Flags().IntVarP(&logsLines, "lines", "l", 50, "Number of log lines to show")
+	logsCmd.Flags().IntVar(&logsLines, "lines", 50, "Number of log lines to show")
 	serviceCmd.AddCommand(logsCmd)
 
 	return serviceCmd


### PR DESCRIPTION
## Summary
- Fixed panic when running `tunnelmesh service logs --follow` due to `-l` shorthand being used by both global `--log-level` and the logs command's `--lines` flag
- Removed the `-l` shorthand from `--lines` to resolve the conflict

## Test plan
- [x] Verify `tunnelmesh service logs --help` works without panic
- [x] Verify `tunnelmesh service logs --lines 10` works correctly
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)