### PR TITLE
Fix macOS service logs and change domain suffix to .tunnelmesh

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A peer-to-peer mesh networking tool that creates encrypted tunnels between nodes
 - **P2P Encrypted Tunnels** - Direct SSH-based connections between peers
 - **Coordination Server** - Central hub for peer discovery and IP allocation (not a traffic router)
 - **TUN Interface** - Virtual network interface for transparent IP routing
-- **Built-in DNS** - Local resolver for mesh hostnames (e.g., `node.mesh`)
+- **Built-in DNS** - Local resolver for mesh hostnames (e.g., `node.tunnelmesh`)
 - **Network Monitoring** - Automatic detection of network changes with re-connection
 - **NAT Traversal** - Supports both direct and reverse connections for peers behind NAT
 - **Multi-Platform** - Linux, macOS, and Windows support
@@ -71,7 +71,7 @@ auth_token: "your-secure-token"
 mesh_cidr: "10.99.0.0/16"
 
 # Domain suffix for hostnames
-domain_suffix: ".mesh"
+domain_suffix: ".tunnelmesh"
 
 # Admin web interface
 admin:

--- a/docker/config/server.yaml
+++ b/docker/config/server.yaml
@@ -2,7 +2,7 @@
 listen: ":8080"
 auth_token: "docker-test-token-123"
 mesh_cidr: "10.99.0.0/16"
-domain_suffix: ".mesh"
+domain_suffix: ".tunnelmesh"
 
 # Server joins the mesh as a client node
 join_mesh:

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -86,7 +86,7 @@ auth_token: "change-me-to-a-secure-token"
 mesh_cidr: "10.99.0.0/16"
 
 # Domain suffix for mesh DNS resolution
-domain_suffix: ".mesh"
+domain_suffix: ".tunnelmesh"
 
 # Enable the admin web dashboard
 admin:
@@ -113,7 +113,7 @@ auth_token: "change-me-to-a-secure-token"
 mesh_cidr: "10.99.0.0/16"
 
 # Domain suffix for mesh DNS resolution
-domain_suffix: ".mesh"
+domain_suffix: ".tunnelmesh"
 
 # Enable the admin web dashboard
 admin:
@@ -221,7 +221,7 @@ tun:
   name: "tun-mesh0"
   mtu: 1400
 
-# Local DNS resolver for .mesh domains
+# Local DNS resolver for .tunnelmesh domains
 dns:
   enabled: true
   listen: "127.0.0.53:5353"
@@ -314,7 +314,7 @@ tunnelmesh status
 tunnelmesh peers
 
 # Once other peers are connected, ping them by name
-ping otherpeer.mesh
+ping otherpeer.tunnelmesh
 ```
 
 Check the admin dashboard on the server—your peer should now appear in the list.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,7 +67,7 @@ func LoadServerConfig(path string) (*ServerConfig, error) {
 		cfg.MeshCIDR = "10.99.0.0/16"
 	}
 	if cfg.DomainSuffix == "" {
-		cfg.DomainSuffix = ".mesh"
+		cfg.DomainSuffix = ".tunnelmesh"
 	}
 	// Admin enabled by default
 	cfg.Admin.Enabled = true

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,7 +18,7 @@ func TestLoadServerConfig(t *testing.T) {
 listen: ":8080"
 auth_token: "test-token-123"
 mesh_cidr: "10.99.0.0/16"
-domain_suffix: ".mesh"
+domain_suffix: ".tunnelmesh"
 `
 	configPath := testutil.TempFile(t, dir, "server.yaml", content)
 
@@ -28,7 +28,7 @@ domain_suffix: ".mesh"
 	assert.Equal(t, ":8080", cfg.Listen)
 	assert.Equal(t, "test-token-123", cfg.AuthToken)
 	assert.Equal(t, "10.99.0.0/16", cfg.MeshCIDR)
-	assert.Equal(t, ".mesh", cfg.DomainSuffix)
+	assert.Equal(t, ".tunnelmesh", cfg.DomainSuffix)
 }
 
 func TestLoadServerConfig_Defaults(t *testing.T) {
@@ -49,7 +49,7 @@ auth_token: "secret"
 	assert.Equal(t, "secret", cfg.AuthToken)
 	// Check defaults
 	assert.Equal(t, "10.99.0.0/16", cfg.MeshCIDR)
-	assert.Equal(t, ".mesh", cfg.DomainSuffix)
+	assert.Equal(t, ".tunnelmesh", cfg.DomainSuffix)
 }
 
 func TestLoadServerConfig_FileNotFound(t *testing.T) {
@@ -161,7 +161,7 @@ func TestServerConfig_Validate(t *testing.T) {
 				Listen:       ":8080",
 				AuthToken:    "token",
 				MeshCIDR:     "10.99.0.0/16",
-				DomainSuffix: ".mesh",
+				DomainSuffix: ".tunnelmesh",
 			},
 			wantErr: false,
 		},
@@ -170,7 +170,7 @@ func TestServerConfig_Validate(t *testing.T) {
 			cfg: ServerConfig{
 				AuthToken:    "token",
 				MeshCIDR:     "10.99.0.0/16",
-				DomainSuffix: ".mesh",
+				DomainSuffix: ".tunnelmesh",
 			},
 			wantErr: true,
 		},
@@ -179,7 +179,7 @@ func TestServerConfig_Validate(t *testing.T) {
 			cfg: ServerConfig{
 				Listen:       ":8080",
 				MeshCIDR:     "10.99.0.0/16",
-				DomainSuffix: ".mesh",
+				DomainSuffix: ".tunnelmesh",
 			},
 			wantErr: true,
 		},
@@ -189,7 +189,7 @@ func TestServerConfig_Validate(t *testing.T) {
 				Listen:       ":8080",
 				AuthToken:    "token",
 				MeshCIDR:     "invalid",
-				DomainSuffix: ".mesh",
+				DomainSuffix: ".tunnelmesh",
 			},
 			wantErr: true,
 		},

--- a/internal/coord/client_test.go
+++ b/internal/coord/client_test.go
@@ -15,7 +15,7 @@ func TestClient_Register(t *testing.T) {
 		Listen:       ":0",
 		AuthToken:    "test-token",
 		MeshCIDR:     "10.99.0.0/16",
-		DomainSuffix: ".mesh",
+		DomainSuffix: ".tunnelmesh",
 	}
 	srv, err := NewServer(cfg)
 	require.NoError(t, err)
@@ -32,7 +32,7 @@ func TestClient_Register(t *testing.T) {
 
 	assert.Equal(t, "10.99.0.1", resp.MeshIP)
 	assert.Equal(t, "10.99.0.0/16", resp.MeshCIDR)
-	assert.Equal(t, ".mesh", resp.Domain)
+	assert.Equal(t, ".tunnelmesh", resp.Domain)
 }
 
 func TestClient_ListPeers(t *testing.T) {
@@ -40,7 +40,7 @@ func TestClient_ListPeers(t *testing.T) {
 		Listen:       ":0",
 		AuthToken:    "test-token",
 		MeshCIDR:     "10.99.0.0/16",
-		DomainSuffix: ".mesh",
+		DomainSuffix: ".tunnelmesh",
 	}
 	srv, err := NewServer(cfg)
 	require.NoError(t, err)
@@ -67,7 +67,7 @@ func TestClient_Heartbeat(t *testing.T) {
 		Listen:       ":0",
 		AuthToken:    "test-token",
 		MeshCIDR:     "10.99.0.0/16",
-		DomainSuffix: ".mesh",
+		DomainSuffix: ".tunnelmesh",
 	}
 	srv, err := NewServer(cfg)
 	require.NoError(t, err)
@@ -91,7 +91,7 @@ func TestClient_HeartbeatNotFound(t *testing.T) {
 		Listen:       ":0",
 		AuthToken:    "test-token",
 		MeshCIDR:     "10.99.0.0/16",
-		DomainSuffix: ".mesh",
+		DomainSuffix: ".tunnelmesh",
 	}
 	srv, err := NewServer(cfg)
 	require.NoError(t, err)
@@ -111,7 +111,7 @@ func TestClient_Deregister(t *testing.T) {
 		Listen:       ":0",
 		AuthToken:    "test-token",
 		MeshCIDR:     "10.99.0.0/16",
-		DomainSuffix: ".mesh",
+		DomainSuffix: ".tunnelmesh",
 	}
 	srv, err := NewServer(cfg)
 	require.NoError(t, err)
@@ -143,7 +143,7 @@ func TestClient_GetDNSRecords(t *testing.T) {
 		Listen:       ":0",
 		AuthToken:    "test-token",
 		MeshCIDR:     "10.99.0.0/16",
-		DomainSuffix: ".mesh",
+		DomainSuffix: ".tunnelmesh",
 	}
 	srv, err := NewServer(cfg)
 	require.NoError(t, err)

--- a/internal/coord/server_test.go
+++ b/internal/coord/server_test.go
@@ -18,7 +18,7 @@ func newTestServer(t *testing.T) *Server {
 		Listen:       ":0",
 		AuthToken:    "test-token",
 		MeshCIDR:     "10.99.0.0/16",
-		DomainSuffix: ".mesh",
+		DomainSuffix: ".tunnelmesh",
 		Admin:        config.AdminConfig{Enabled: true},
 	}
 	srv, err := NewServer(cfg)
@@ -65,7 +65,7 @@ func TestServer_Register_Success(t *testing.T) {
 
 	assert.NotEmpty(t, resp.MeshIP)
 	assert.Equal(t, "10.99.0.0/16", resp.MeshCIDR)
-	assert.Equal(t, ".mesh", resp.Domain)
+	assert.Equal(t, ".tunnelmesh", resp.Domain)
 }
 
 func TestServer_Register_Unauthorized(t *testing.T) {

--- a/internal/dns/resolver_test.go
+++ b/internal/dns/resolver_test.go
@@ -13,37 +13,37 @@ import (
 )
 
 func TestResolver_AddRecord(t *testing.T) {
-	r := NewResolver(".mesh", 60)
+	r := NewResolver(".tunnelmesh", 60)
 
 	r.AddRecord("mynode", "10.99.0.1")
 	r.AddRecord("other", "10.99.0.2")
 
-	ip, ok := r.Resolve("mynode.mesh")
+	ip, ok := r.Resolve("mynode.tunnelmesh")
 	assert.True(t, ok)
 	assert.Equal(t, "10.99.0.1", ip)
 
-	ip, ok = r.Resolve("other.mesh")
+	ip, ok = r.Resolve("other.tunnelmesh")
 	assert.True(t, ok)
 	assert.Equal(t, "10.99.0.2", ip)
 }
 
 func TestResolver_RemoveRecord(t *testing.T) {
-	r := NewResolver(".mesh", 60)
+	r := NewResolver(".tunnelmesh", 60)
 
 	r.AddRecord("mynode", "10.99.0.1")
 
-	ip, ok := r.Resolve("mynode.mesh")
+	ip, ok := r.Resolve("mynode.tunnelmesh")
 	assert.True(t, ok)
 	assert.Equal(t, "10.99.0.1", ip)
 
 	r.RemoveRecord("mynode")
 
-	_, ok = r.Resolve("mynode.mesh")
+	_, ok = r.Resolve("mynode.tunnelmesh")
 	assert.False(t, ok)
 }
 
 func TestResolver_UpdateRecords(t *testing.T) {
-	r := NewResolver(".mesh", 60)
+	r := NewResolver(".tunnelmesh", 60)
 
 	// Initial records
 	r.AddRecord("node1", "10.99.0.1")
@@ -56,23 +56,23 @@ func TestResolver_UpdateRecords(t *testing.T) {
 	})
 
 	// Old records should be gone
-	_, ok := r.Resolve("node1.mesh")
+	_, ok := r.Resolve("node1.tunnelmesh")
 	assert.False(t, ok)
-	_, ok = r.Resolve("node2.mesh")
+	_, ok = r.Resolve("node2.tunnelmesh")
 	assert.False(t, ok)
 
 	// New records should exist
-	ip, ok := r.Resolve("node3.mesh")
+	ip, ok := r.Resolve("node3.tunnelmesh")
 	assert.True(t, ok)
 	assert.Equal(t, "10.99.0.3", ip)
 }
 
 func TestResolver_ResolveWithoutSuffix(t *testing.T) {
-	r := NewResolver(".mesh", 60)
+	r := NewResolver(".tunnelmesh", 60)
 	r.AddRecord("mynode", "10.99.0.1")
 
 	// Should work with or without suffix
-	ip, ok := r.Resolve("mynode.mesh")
+	ip, ok := r.Resolve("mynode.tunnelmesh")
 	assert.True(t, ok)
 	assert.Equal(t, "10.99.0.1", ip)
 
@@ -82,9 +82,9 @@ func TestResolver_ResolveWithoutSuffix(t *testing.T) {
 }
 
 func TestResolver_ResolveNonexistent(t *testing.T) {
-	r := NewResolver(".mesh", 60)
+	r := NewResolver(".tunnelmesh", 60)
 
-	_, ok := r.Resolve("unknown.mesh")
+	_, ok := r.Resolve("unknown.tunnelmesh")
 	assert.False(t, ok)
 }
 
@@ -92,7 +92,7 @@ func TestResolver_DNSServer(t *testing.T) {
 	port := testutil.FreePort(t)
 	addr := "127.0.0.1:" + strconv.Itoa(port)
 
-	r := NewResolver(".mesh", 60)
+	r := NewResolver(".tunnelmesh", 60)
 	r.AddRecord("testhost", "10.99.0.42")
 
 	// Start server
@@ -110,7 +110,7 @@ func TestResolver_DNSServer(t *testing.T) {
 	// Query the DNS server
 	c := new(dns.Client)
 	m := new(dns.Msg)
-	m.SetQuestion("testhost.mesh.", dns.TypeA)
+	m.SetQuestion("testhost.tunnelmesh.", dns.TypeA)
 
 	resp, _, err := c.Exchange(m, addr)
 	require.NoError(t, err)
@@ -126,7 +126,7 @@ func TestResolver_DNSServer_NXDOMAIN(t *testing.T) {
 	port := testutil.FreePort(t)
 	addr := "127.0.0.1:" + strconv.Itoa(port)
 
-	r := NewResolver(".mesh", 60)
+	r := NewResolver(".tunnelmesh", 60)
 
 	go func() {
 		_ = r.ListenAndServe(addr)
@@ -137,7 +137,7 @@ func TestResolver_DNSServer_NXDOMAIN(t *testing.T) {
 
 	c := new(dns.Client)
 	m := new(dns.Msg)
-	m.SetQuestion("unknown.mesh.", dns.TypeA)
+	m.SetQuestion("unknown.tunnelmesh.", dns.TypeA)
 
 	resp, _, err := c.Exchange(m, addr)
 	require.NoError(t, err)
@@ -146,7 +146,7 @@ func TestResolver_DNSServer_NXDOMAIN(t *testing.T) {
 }
 
 func TestResolver_ListRecords(t *testing.T) {
-	r := NewResolver(".mesh", 60)
+	r := NewResolver(".tunnelmesh", 60)
 
 	r.AddRecord("node1", "10.99.0.1")
 	r.AddRecord("node2", "10.99.0.2")

--- a/server.yaml.example
+++ b/server.yaml.example
@@ -13,4 +13,4 @@ auth_token: "your-secure-token-here"
 mesh_cidr: "10.99.0.0/16"
 
 # Domain suffix for mesh hostnames
-domain_suffix: ".mesh"
+domain_suffix: ".tunnelmesh"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -30,7 +30,7 @@ variable "mesh_cidr" {
 variable "domain_suffix" {
   description = "Domain suffix for mesh hostnames"
   type        = string
-  default     = ".mesh"
+  default     = ".tunnelmesh"
 }
 
 variable "github_owner" {


### PR DESCRIPTION
## Summary
- **Fix macOS service logs**: Read from launchd log files (`/var/log/tunnelmesh.{out,err}.log`) instead of trying to query the macOS unified logging system which doesn't capture the app output
- **Change domain suffix**: Changed default from `.mesh` to `.tunnelmesh` for internal DNS resolution

## Changes
- `internal/svc/logs.go`: Updated `viewLogsDarwin()` to read from log files using `tail`
- `internal/config/config.go`: Changed default domain suffix
- `terraform/variables.tf`: Changed default domain suffix
- Updated all documentation, examples, and tests to use `.tunnelmesh`

## Test plan
- [x] All existing tests pass
- [x] `tunnelmesh service logs` now properly shows application output on macOS
- [x] DNS resolution works with `.tunnelmesh` suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)