### PR TITLE
Fix SSH connection being garbage collected causing tunnel to close

### DIFF
--- a/cmd/tunnelmesh/main.go
+++ b/cmd/tunnelmesh/main.go
@@ -1018,7 +1018,8 @@ func establishTunnel(ctx context.Context, peer proto.Peer, myName string, sshCli
 		}
 
 		// Create tunnel and add to manager
-		tun := tunnel.NewTunnel(channel, peer.Name)
+		// Use NewTunnelWithClient to keep SSH connection alive (prevents GC from closing it)
+		tun := tunnel.NewTunnelWithClient(channel, peer.Name, sshConn)
 		tunnelMgr.Add(peer.Name, tun)
 
 		log.Info().Str("peer", peer.Name).Msg("tunnel established")


### PR DESCRIPTION
## Summary
- Store SSH client reference in Tunnel struct to prevent garbage collection
- Close SSH client when tunnel is closed

## Problem
After establishing a tunnel via direct SSH connection, the `sshConn` variable went out of scope when `establishTunnel()` returned. Go's garbage collector would then collect the SSH client, closing the underlying TCP connection and causing the tunnel to receive EOF ~4 seconds after creation.

## Solution
Added `NewTunnelWithClient()` constructor that stores a reference to the SSH client in the Tunnel struct. When the tunnel is closed, it also closes the SSH client.

## Test plan
- [x] All tests pass
- [ ] Test tunnel persistence over time with two peers

🤖 Generated with [Claude Code](https://claude.com/claude-code)