### PR TITLE
Keep peer record on shutdown for sticky mesh IPs

### DIFF
--- a/cmd/tunnelmesh/main.go
+++ b/cmd/tunnelmesh/main.go
@@ -651,12 +651,9 @@ func runJoinWithConfig(ctx context.Context, cfg *config.PeerConfig) error {
 	// Close all tunnels
 	tunnelMgr.CloseAll()
 
-	// Deregister
-	if err := client.Deregister(cfg.Name); err != nil {
-		log.Warn().Err(err).Msg("failed to deregister")
-	} else {
-		log.Info().Msg("deregistered from mesh")
-	}
+	// Don't deregister on shutdown - keep the peer record so we get the same
+	// mesh IP when we reconnect. Use 'tunnelmesh leave' for intentional removal.
+	log.Info().Msg("disconnected from mesh (peer record retained for sticky IP)")
 
 	if resolver != nil {
 		_ = resolver.Shutdown()


### PR DESCRIPTION
## Summary
- Don't deregister peers on shutdown
- Peers keep the same mesh IP across service restarts

## Problem
When a service restarted, it would:
1. Deregister (releasing mesh IP like 10.99.0.1)
2. Start up and re-register
3. Get a new IP (like 10.99.0.4) because the allocator doesn't reuse released IPs immediately

This caused DNS resolution issues where peers would resolve to stale IPs.

## Solution
Don't call `Deregister` on shutdown. The peer record stays, so on restart the peer gets the same mesh IP because the `existing` check in registration finds the record.

Users can still explicitly leave the mesh with `tunnelmesh leave`.

## Test plan
- [x] All existing tests pass
- [ ] Manual test: restart service and verify mesh IP stays the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)