### PR TITLE
Add exit node routing feature

### DIFF
--- a/internal/coord/client.go
+++ b/internal/coord/client.go
@@ -73,6 +73,15 @@ func (c *Client) Register(name, publicKey string, publicIPs, privateIPs []string
 
 // ListPeers returns a list of all registered peers.
 func (c *Client) ListPeers() ([]proto.Peer, error) {
+	resp, err := c.ListPeersResponse()
+	if err != nil {
+		return nil, err
+	}
+	return resp.Peers, nil
+}
+
+// ListPeersResponse returns the full peer list response including network settings.
+func (c *Client) ListPeersResponse() (*proto.PeerListResponse, error) {
 	resp, err := c.doRequest(http.MethodGet, "/api/v1/peers", nil)
 	if err != nil {
 		return nil, err
@@ -88,7 +97,7 @@ func (c *Client) ListPeers() ([]proto.Peer, error) {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 
-	return result.Peers, nil
+	return &result, nil
 }
 
 // Heartbeat sends a heartbeat to maintain presence.

--- a/internal/coord/web/css/style.css
+++ b/internal/coord/web/css/style.css
@@ -106,7 +106,7 @@ main {
     color: #3fb950;
 }
 
-#peers-section, #dns-section {
+#peers-section, #dns-section, #settings-section {
     background: #0d1117;
     border-radius: 6px;
     padding: 0;
@@ -114,7 +114,7 @@ main {
     margin-bottom: 1.5rem;
 }
 
-#peers-section h2, #dns-section h2 {
+#peers-section h2, #dns-section h2, #settings-section h2 {
     font-size: 1rem;
     font-weight: 600;
     padding: 1rem;
@@ -123,6 +123,91 @@ main {
     background: #161b22;
     border-bottom: 1px solid #30363d;
     border-radius: 6px 6px 0 0;
+}
+
+/* Settings form styles */
+.settings-form {
+    padding: 1rem;
+}
+
+.setting-row {
+    margin-bottom: 1rem;
+}
+
+.setting-row:last-child {
+    margin-bottom: 0;
+}
+
+.setting-row label {
+    display: block;
+    color: #e6edf3;
+    font-weight: 500;
+    margin-bottom: 0.5rem;
+}
+
+.setting-row .help-text {
+    color: #8b949e;
+    font-size: 0.75rem;
+    margin-bottom: 0.5rem;
+}
+
+.setting-row select,
+.setting-row textarea {
+    width: 100%;
+    max-width: 400px;
+    padding: 0.5rem;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    background: #0d1117;
+    color: #e6edf3;
+    font-family: inherit;
+    font-size: 0.875rem;
+}
+
+.setting-row textarea {
+    max-width: 500px;
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+    resize: vertical;
+}
+
+.setting-row select:focus,
+.setting-row textarea:focus {
+    outline: none;
+    border-color: #58a6ff;
+    box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.3);
+}
+
+.btn-primary {
+    background: #238636;
+    color: #ffffff;
+    border: 1px solid rgba(240, 246, 252, 0.1);
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.2s;
+}
+
+.btn-primary:hover {
+    background: #2ea043;
+}
+
+.btn-primary:active {
+    background: #238636;
+}
+
+.save-status {
+    margin-left: 1rem;
+    font-size: 0.875rem;
+}
+
+.save-status.success {
+    color: #3fb950;
+}
+
+.save-status.error {
+    color: #f85149;
 }
 
 table {

--- a/internal/coord/web/index.html
+++ b/internal/coord/web/index.html
@@ -63,6 +63,27 @@
                 No DNS records yet.
             </div>
         </section>
+
+        <section id="settings-section">
+            <h2>Network Settings</h2>
+            <div class="settings-form">
+                <div class="setting-row">
+                    <label for="exit-node-select">Exit Node:</label>
+                    <select id="exit-node-select">
+                        <option value="">Disabled</option>
+                    </select>
+                </div>
+                <div class="setting-row">
+                    <label for="network-exceptions">Network Exceptions (CIDRs):</label>
+                    <p class="help-text">Traffic to these ranges bypasses exit node. Peer IPs in these ranges are skipped for tunnel connections.</p>
+                    <textarea id="network-exceptions" rows="6" placeholder="100.64.0.0/10&#10;10.0.0.0/8&#10;172.16.0.0/12&#10;192.168.0.0/16"></textarea>
+                </div>
+                <div class="setting-row">
+                    <button id="save-settings" class="btn-primary">Save Settings</button>
+                    <span id="save-status" class="save-status"></span>
+                </div>
+            </div>
+        </section>
     </main>
 
     <footer>

--- a/internal/negotiate/negotiator_test.go
+++ b/internal/negotiate/negotiator_test.go
@@ -265,3 +265,141 @@ func TestConfig_Validate(t *testing.T) {
 		})
 	}
 }
+
+func TestNegotiator_SetExceptionCIDRs(t *testing.T) {
+	neg := NewNegotiator(Config{
+		ProbeTimeout: 500 * time.Millisecond,
+	})
+
+	// Valid CIDRs
+	err := neg.SetExceptionCIDRs([]string{"192.168.0.0/16", "10.0.0.0/8", "100.64.0.0/10"})
+	require.NoError(t, err)
+
+	neg.exceptionMu.RLock()
+	assert.Len(t, neg.exceptionCIDRs, 3)
+	neg.exceptionMu.RUnlock()
+}
+
+func TestNegotiator_SetExceptionCIDRs_Invalid(t *testing.T) {
+	neg := NewNegotiator(Config{
+		ProbeTimeout: 500 * time.Millisecond,
+	})
+
+	// Invalid CIDR
+	err := neg.SetExceptionCIDRs([]string{"192.168.0.0/16", "not-a-cidr"})
+	require.Error(t, err)
+}
+
+func TestNegotiator_isExcepted(t *testing.T) {
+	neg := NewNegotiator(Config{
+		ProbeTimeout: 500 * time.Millisecond,
+	})
+
+	err := neg.SetExceptionCIDRs([]string{"192.168.0.0/16", "100.64.0.0/10"})
+	require.NoError(t, err)
+
+	tests := []struct {
+		ip       string
+		excepted bool
+	}{
+		{"192.168.1.1", true},
+		{"192.168.254.254", true},
+		{"100.64.0.1", true},
+		{"100.127.255.255", true},
+		{"8.8.8.8", false},
+		{"10.0.0.1", false},
+		{"172.16.0.1", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ip, func(t *testing.T) {
+			result := neg.isExcepted(tt.ip)
+			assert.Equal(t, tt.excepted, result, "IP %s expected excepted=%v", tt.ip, tt.excepted)
+		})
+	}
+}
+
+func TestNegotiator_filterAddresses(t *testing.T) {
+	neg := NewNegotiator(Config{
+		ProbeTimeout: 500 * time.Millisecond,
+	})
+
+	// Set exceptions
+	err := neg.SetExceptionCIDRs([]string{"100.64.0.0/10"})
+	require.NoError(t, err)
+
+	addrs := []string{
+		"8.8.8.8:2222",
+		"100.64.1.1:2222",  // Tailscale - should be filtered
+		"192.168.1.1:2222",
+		"100.127.0.1:2222", // Tailscale - should be filtered
+	}
+
+	filtered := neg.filterAddresses(addrs)
+
+	assert.Len(t, filtered, 2)
+	assert.Contains(t, filtered, "8.8.8.8:2222")
+	assert.Contains(t, filtered, "192.168.1.1:2222")
+	assert.NotContains(t, filtered, "100.64.1.1:2222")
+	assert.NotContains(t, filtered, "100.127.0.1:2222")
+}
+
+func TestNegotiator_filterAddresses_NoExceptions(t *testing.T) {
+	neg := NewNegotiator(Config{
+		ProbeTimeout: 500 * time.Millisecond,
+	})
+
+	// No exceptions set
+	addrs := []string{
+		"8.8.8.8:2222",
+		"100.64.1.1:2222",
+	}
+
+	filtered := neg.filterAddresses(addrs)
+
+	// Should return all addresses unchanged
+	assert.Equal(t, addrs, filtered)
+}
+
+func TestNegotiator_ProbeAll_WithExceptions(t *testing.T) {
+	neg := NewNegotiator(Config{
+		ProbeTimeout: 100 * time.Millisecond,
+	})
+
+	// Set exception for 100.64.0.0/10 (Tailscale)
+	err := neg.SetExceptionCIDRs([]string{"100.64.0.0/10"})
+	require.NoError(t, err)
+
+	peer := &PeerInfo{
+		ID:         "peer1",
+		PublicIP:   "8.8.8.8",              // Will fail to connect but won't be filtered
+		PrivateIPs: []string{"100.64.1.1"}, // Tailscale IP - should be filtered
+		SSHPort:    2222,
+	}
+
+	ctx := context.Background()
+	results := neg.ProbeAll(ctx, peer)
+
+	// Should only have probed one address (the public IP)
+	// The Tailscale IP should have been filtered out
+	assert.Len(t, results, 1)
+	assert.Equal(t, "8.8.8.8:2222", results[0].Address)
+	// It won't be reachable but the important thing is the filtering
+	assert.False(t, results[0].Reachable)
+}
+
+func TestPeerInfo_AllAddresses(t *testing.T) {
+	info := &PeerInfo{
+		ID:         "peer1",
+		PublicIP:   "1.2.3.4",
+		PrivateIPs: []string{"192.168.1.10", "10.0.0.5"},
+		SSHPort:    2222,
+	}
+
+	// Private IPs should come first (LAN preferred)
+	addrs := info.AllAddresses()
+	assert.Len(t, addrs, 3)
+	assert.Equal(t, "192.168.1.10:2222", addrs[0])
+	assert.Equal(t, "10.0.0.5:2222", addrs[1])
+	assert.Equal(t, "1.2.3.4:2222", addrs[2])
+}

--- a/internal/routing/exit.go
+++ b/internal/routing/exit.go
@@ -1,0 +1,233 @@
+// Package routing provides exit node handling for the mesh network.
+package routing
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// ExitConfig holds configuration for the exit handler.
+type ExitConfig struct {
+	// ExitIP is the public IP address used for SNAT (defaults to auto-detect)
+	ExitIP net.IP
+	// NATTimeout is how long to keep NAT entries alive
+	NATTimeout time.Duration
+	// CleanupInterval is how often to clean up stale NAT entries
+	CleanupInterval time.Duration
+}
+
+// DefaultExitHandler implements ExitHandler using a raw socket or TUN device.
+type DefaultExitHandler struct {
+	config    ExitConfig
+	natTable  *NATTable
+	tunnels   TunnelProvider
+	forwarder *Forwarder
+
+	// Exit TUN device for sending/receiving internet traffic
+	exitTUN   TUNDevice
+	exitTUNMu sync.RWMutex
+
+	// Track which peer a response should go to
+	peerMu sync.RWMutex
+
+	// Context for cleanup goroutine
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// NewExitHandler creates a new exit handler.
+func NewExitHandler(cfg ExitConfig, tunnels TunnelProvider, forwarder *Forwarder) *DefaultExitHandler {
+	if cfg.NATTimeout == 0 {
+		cfg.NATTimeout = NATTimeout
+	}
+	if cfg.CleanupInterval == 0 {
+		cfg.CleanupInterval = NATCleanupInterval
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	h := &DefaultExitHandler{
+		config:    cfg,
+		natTable:  NewNATTable(cfg.ExitIP, cfg.NATTimeout),
+		tunnels:   tunnels,
+		forwarder: forwarder,
+		ctx:       ctx,
+		cancel:    cancel,
+	}
+
+	// Start cleanup goroutine
+	go h.cleanupLoop()
+
+	return h
+}
+
+// SetExitTUN sets the TUN device for exit traffic.
+func (h *DefaultExitHandler) SetExitTUN(tun TUNDevice) {
+	h.exitTUNMu.Lock()
+	h.exitTUN = tun
+	h.exitTUNMu.Unlock()
+}
+
+// SetExitIP updates the exit IP address.
+func (h *DefaultExitHandler) SetExitIP(ip net.IP) {
+	h.config.ExitIP = ip
+	h.natTable.SetExitIP(ip)
+}
+
+// HandleExitPacket processes a packet received from a peer for internet routing.
+// This is called by the forwarder when it receives a ProtoExitPacket.
+func (h *DefaultExitHandler) HandleExitPacket(peerName string, packet []byte) error {
+	// Perform NAT translation
+	translated, err := h.natTable.TranslateOutbound(packet, peerName)
+	if err != nil {
+		return fmt.Errorf("NAT translation failed: %w", err)
+	}
+
+	// Send to internet via exit TUN
+	h.exitTUNMu.RLock()
+	tun := h.exitTUN
+	h.exitTUNMu.RUnlock()
+
+	if tun == nil {
+		return fmt.Errorf("exit TUN not configured")
+	}
+
+	_, err = tun.Write(translated)
+	if err != nil {
+		return fmt.Errorf("write to exit TUN: %w", err)
+	}
+
+	log.Trace().
+		Str("peer", peerName).
+		Int("len", len(packet)).
+		Msg("forwarded exit packet to internet")
+
+	return nil
+}
+
+// Run starts the exit handler loop that reads responses from the internet.
+func (h *DefaultExitHandler) Run(ctx context.Context) error {
+	h.exitTUNMu.RLock()
+	tun := h.exitTUN
+	h.exitTUNMu.RUnlock()
+
+	if tun == nil {
+		return fmt.Errorf("exit TUN not set")
+	}
+
+	log.Info().Msg("starting exit handler")
+
+	buf := make([]byte, MaxPacketSize)
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info().Msg("exit handler stopped")
+			return ctx.Err()
+		default:
+		}
+
+		// Read packet from exit TUN (internet responses)
+		n, err := tun.Read(buf)
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			log.Error().Err(err).Msg("exit TUN read error")
+			continue
+		}
+
+		if n == 0 {
+			continue
+		}
+
+		packet := buf[:n]
+
+		// Check if this is IPv4
+		if len(packet) < 1 || packet[0]>>4 != 4 {
+			continue
+		}
+
+		// Perform reverse NAT translation
+		peerName, translated, err := h.natTable.TranslateInbound(packet)
+		if err != nil {
+			// Not a tracked connection, ignore
+			log.Trace().Err(err).Msg("no NAT entry for inbound packet")
+			continue
+		}
+
+		// Send back to the peer via tunnel
+		if err := h.sendToPeer(peerName, translated); err != nil {
+			log.Debug().Err(err).Str("peer", peerName).Msg("failed to send response to peer")
+		}
+	}
+}
+
+// sendToPeer sends a translated response packet back to the originating peer.
+func (h *DefaultExitHandler) sendToPeer(peerName string, packet []byte) error {
+	tunnel, ok := h.tunnels.Get(peerName)
+	if !ok {
+		return fmt.Errorf("no tunnel to peer %s", peerName)
+	}
+
+	// Write as mesh packet (the peer's forwarder will write to its TUN)
+	if err := h.writeFrame(tunnel, packet, ProtoMeshPacket); err != nil {
+		return fmt.Errorf("write to tunnel: %w", err)
+	}
+
+	log.Trace().
+		Str("peer", peerName).
+		Int("len", len(packet)).
+		Msg("sent exit response to peer")
+
+	return nil
+}
+
+// writeFrame writes a framed packet to the tunnel.
+func (h *DefaultExitHandler) writeFrame(w io.Writer, packet []byte, protoType byte) error {
+	// Frame format: [2 bytes length][1 byte proto][payload]
+	frameLen := len(packet) + 1
+	header := make([]byte, FrameHeaderSize)
+	header[0] = byte(frameLen >> 8)
+	header[1] = byte(frameLen)
+	header[2] = protoType
+
+	if _, err := w.Write(header); err != nil {
+		return err
+	}
+	if _, err := w.Write(packet); err != nil {
+		return err
+	}
+	return nil
+}
+
+// cleanupLoop periodically cleans up stale NAT entries.
+func (h *DefaultExitHandler) cleanupLoop() {
+	ticker := time.NewTicker(h.config.CleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-h.ctx.Done():
+			return
+		case <-ticker.C:
+			h.natTable.Cleanup()
+		}
+	}
+}
+
+// Stop stops the exit handler and cleanup goroutine.
+func (h *DefaultExitHandler) Stop() {
+	h.cancel()
+}
+
+// Stats returns exit handler statistics.
+func (h *DefaultExitHandler) Stats() (natEntries int, created, expired uint64) {
+	return h.natTable.Stats()
+}

--- a/internal/routing/nat.go
+++ b/internal/routing/nat.go
@@ -1,0 +1,470 @@
+// Package routing provides packet routing and NAT functionality for the mesh network.
+package routing
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	// NATPortMin is the minimum NAT port to use
+	NATPortMin = 10000
+	// NATPortMax is the maximum NAT port to use
+	NATPortMax = 65535
+	// NATTimeout is the default timeout for NAT entries
+	NATTimeout = 5 * time.Minute
+	// NATCleanupInterval is how often to clean up stale entries
+	NATCleanupInterval = 30 * time.Second
+)
+
+// NATEntry tracks a single NAT translation.
+type NATEntry struct {
+	OriginalSrcIP   net.IP
+	OriginalSrcPort uint16
+	OriginalDstIP   net.IP
+	OriginalDstPort uint16
+	Protocol        uint8 // TCP=6, UDP=17, ICMP=1
+	NATPort         uint16
+	PeerName        string    // Peer that sent this traffic
+	LastSeen        time.Time
+	Created         time.Time
+}
+
+// NATTable manages NAT translations for exit node traffic.
+type NATTable struct {
+	mu sync.RWMutex
+
+	// Keyed by NAT port for reverse lookups (internet -> peer)
+	byNATPort map[uint16]*NATEntry
+
+	// Keyed by original connection for forward lookups (peer -> internet)
+	// Key format: "proto:srcIP:srcPort:dstIP:dstPort"
+	byOriginal map[string]*NATEntry
+
+	nextPort uint16
+	timeout  time.Duration
+	exitIP   net.IP // The exit node's public IP for SNAT
+
+	// Stats
+	entriesCreated uint64
+	entriesExpired uint64
+}
+
+// NewNATTable creates a new NAT table.
+func NewNATTable(exitIP net.IP, timeout time.Duration) *NATTable {
+	if timeout == 0 {
+		timeout = NATTimeout
+	}
+
+	return &NATTable{
+		byNATPort:  make(map[uint16]*NATEntry),
+		byOriginal: make(map[string]*NATEntry),
+		nextPort:   NATPortMin,
+		timeout:    timeout,
+		exitIP:     exitIP,
+	}
+}
+
+// SetExitIP updates the exit node's public IP address.
+func (n *NATTable) SetExitIP(ip net.IP) {
+	n.mu.Lock()
+	n.exitIP = ip
+	n.mu.Unlock()
+}
+
+// allocatePort finds an available NAT port.
+func (n *NATTable) allocatePort() (uint16, error) {
+	startPort := n.nextPort
+	for {
+		port := n.nextPort
+		n.nextPort++
+		if n.nextPort > NATPortMax {
+			n.nextPort = NATPortMin
+		}
+
+		if _, exists := n.byNATPort[port]; !exists {
+			return port, nil
+		}
+
+		// Wrapped around without finding a port
+		if n.nextPort == startPort {
+			return 0, fmt.Errorf("no available NAT ports")
+		}
+	}
+}
+
+// connectionKey generates a key for the byOriginal map.
+func connectionKey(proto uint8, srcIP net.IP, srcPort uint16, dstIP net.IP, dstPort uint16) string {
+	return fmt.Sprintf("%d:%s:%d:%s:%d", proto, srcIP.String(), srcPort, dstIP.String(), dstPort)
+}
+
+// TranslateOutbound performs SNAT on an outgoing packet.
+// Returns the translated packet with source IP/port rewritten.
+func (n *NATTable) TranslateOutbound(packet []byte, peerName string) ([]byte, error) {
+	if len(packet) < 20 {
+		return nil, fmt.Errorf("packet too short")
+	}
+
+	// Parse IPv4 header
+	info, err := ParseIPv4Packet(packet)
+	if err != nil {
+		return nil, fmt.Errorf("parse packet: %w", err)
+	}
+
+	// Get or create NAT entry
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	var srcPort, dstPort uint16
+	var protoOffset int
+
+	switch info.Protocol {
+	case 6: // TCP
+		if len(packet) < int(info.HeaderLen)+4 {
+			return nil, fmt.Errorf("TCP packet too short")
+		}
+		protoOffset = int(info.HeaderLen)
+		srcPort = binary.BigEndian.Uint16(packet[protoOffset : protoOffset+2])
+		dstPort = binary.BigEndian.Uint16(packet[protoOffset+2 : protoOffset+4])
+
+	case 17: // UDP
+		if len(packet) < int(info.HeaderLen)+4 {
+			return nil, fmt.Errorf("UDP packet too short")
+		}
+		protoOffset = int(info.HeaderLen)
+		srcPort = binary.BigEndian.Uint16(packet[protoOffset : protoOffset+2])
+		dstPort = binary.BigEndian.Uint16(packet[protoOffset+2 : protoOffset+4])
+
+	case 1: // ICMP
+		// ICMP uses ID field instead of ports
+		if len(packet) < int(info.HeaderLen)+8 {
+			return nil, fmt.Errorf("ICMP packet too short")
+		}
+		protoOffset = int(info.HeaderLen)
+		// ICMP ID is at offset 4-5 within ICMP header
+		srcPort = binary.BigEndian.Uint16(packet[protoOffset+4 : protoOffset+6])
+		dstPort = 0
+
+	default:
+		return nil, fmt.Errorf("unsupported protocol: %d", info.Protocol)
+	}
+
+	key := connectionKey(info.Protocol, info.SrcIP, srcPort, info.DstIP, dstPort)
+	entry, exists := n.byOriginal[key]
+
+	if !exists {
+		// Create new NAT entry
+		natPort, err := n.allocatePort()
+		if err != nil {
+			return nil, err
+		}
+
+		entry = &NATEntry{
+			OriginalSrcIP:   info.SrcIP,
+			OriginalSrcPort: srcPort,
+			OriginalDstIP:   info.DstIP,
+			OriginalDstPort: dstPort,
+			Protocol:        info.Protocol,
+			NATPort:         natPort,
+			PeerName:        peerName,
+			LastSeen:        time.Now(),
+			Created:         time.Now(),
+		}
+
+		n.byOriginal[key] = entry
+		n.byNATPort[natPort] = entry
+		n.entriesCreated++
+
+		log.Debug().
+			Str("peer", peerName).
+			Str("src", fmt.Sprintf("%s:%d", info.SrcIP, srcPort)).
+			Str("dst", fmt.Sprintf("%s:%d", info.DstIP, dstPort)).
+			Uint16("nat_port", natPort).
+			Msg("created NAT entry")
+	} else {
+		entry.LastSeen = time.Now()
+	}
+
+	// Create translated packet
+	translated := make([]byte, len(packet))
+	copy(translated, packet)
+
+	// Rewrite source IP to exit node IP
+	if n.exitIP != nil {
+		copy(translated[12:16], n.exitIP.To4())
+	}
+
+	// Rewrite source port to NAT port
+	switch info.Protocol {
+	case 6, 17: // TCP, UDP
+		binary.BigEndian.PutUint16(translated[protoOffset:protoOffset+2], entry.NATPort)
+	case 1: // ICMP
+		binary.BigEndian.PutUint16(translated[protoOffset+4:protoOffset+6], entry.NATPort)
+	}
+
+	// Recalculate IP header checksum
+	recalculateIPChecksum(translated)
+
+	// Recalculate transport layer checksum
+	switch info.Protocol {
+	case 6: // TCP
+		recalculateTCPChecksum(translated, int(info.HeaderLen))
+	case 17: // UDP
+		recalculateUDPChecksum(translated, int(info.HeaderLen))
+	case 1: // ICMP
+		recalculateICMPChecksum(translated, int(info.HeaderLen))
+	}
+
+	return translated, nil
+}
+
+// TranslateInbound performs reverse NAT on an incoming response packet.
+// Returns the peer name and the translated packet with destination restored.
+func (n *NATTable) TranslateInbound(packet []byte) (string, []byte, error) {
+	if len(packet) < 20 {
+		return "", nil, fmt.Errorf("packet too short")
+	}
+
+	// Parse IPv4 header
+	info, err := ParseIPv4Packet(packet)
+	if err != nil {
+		return "", nil, fmt.Errorf("parse packet: %w", err)
+	}
+
+	var dstPort uint16
+	var protoOffset int
+
+	switch info.Protocol {
+	case 6, 17: // TCP, UDP
+		if len(packet) < int(info.HeaderLen)+4 {
+			return "", nil, fmt.Errorf("packet too short for protocol")
+		}
+		protoOffset = int(info.HeaderLen)
+		dstPort = binary.BigEndian.Uint16(packet[protoOffset+2 : protoOffset+4])
+
+	case 1: // ICMP
+		if len(packet) < int(info.HeaderLen)+8 {
+			return "", nil, fmt.Errorf("ICMP packet too short")
+		}
+		protoOffset = int(info.HeaderLen)
+		// ICMP ID is at offset 4-5
+		dstPort = binary.BigEndian.Uint16(packet[protoOffset+4 : protoOffset+6])
+
+	default:
+		return "", nil, fmt.Errorf("unsupported protocol: %d", info.Protocol)
+	}
+
+	// Look up NAT entry by destination port
+	n.mu.RLock()
+	entry, exists := n.byNATPort[dstPort]
+	if exists {
+		entry.LastSeen = time.Now()
+	}
+	n.mu.RUnlock()
+
+	if !exists {
+		return "", nil, fmt.Errorf("no NAT entry for port %d", dstPort)
+	}
+
+	// Create translated packet
+	translated := make([]byte, len(packet))
+	copy(translated, packet)
+
+	// Rewrite destination IP to original source IP
+	copy(translated[16:20], entry.OriginalSrcIP.To4())
+
+	// Rewrite destination port to original source port
+	switch info.Protocol {
+	case 6, 17: // TCP, UDP
+		binary.BigEndian.PutUint16(translated[protoOffset+2:protoOffset+4], entry.OriginalSrcPort)
+	case 1: // ICMP
+		binary.BigEndian.PutUint16(translated[protoOffset+4:protoOffset+6], entry.OriginalSrcPort)
+	}
+
+	// Recalculate checksums
+	recalculateIPChecksum(translated)
+	switch info.Protocol {
+	case 6:
+		recalculateTCPChecksum(translated, int(info.HeaderLen))
+	case 17:
+		recalculateUDPChecksum(translated, int(info.HeaderLen))
+	case 1:
+		recalculateICMPChecksum(translated, int(info.HeaderLen))
+	}
+
+	return entry.PeerName, translated, nil
+}
+
+// Cleanup removes stale NAT entries.
+func (n *NATTable) Cleanup() int {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	now := time.Now()
+	removed := 0
+
+	for key, entry := range n.byOriginal {
+		if now.Sub(entry.LastSeen) > n.timeout {
+			delete(n.byOriginal, key)
+			delete(n.byNATPort, entry.NATPort)
+			removed++
+			n.entriesExpired++
+		}
+	}
+
+	if removed > 0 {
+		log.Debug().
+			Int("removed", removed).
+			Int("remaining", len(n.byNATPort)).
+			Msg("cleaned up NAT entries")
+	}
+
+	return removed
+}
+
+// Stats returns NAT table statistics.
+func (n *NATTable) Stats() (entries int, created, expired uint64) {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return len(n.byNATPort), n.entriesCreated, n.entriesExpired
+}
+
+// recalculateIPChecksum recalculates the IPv4 header checksum.
+func recalculateIPChecksum(packet []byte) {
+	// Zero out the checksum field
+	packet[10] = 0
+	packet[11] = 0
+
+	// Calculate header length
+	ihl := int(packet[0]&0x0F) * 4
+
+	// Calculate checksum
+	var sum uint32
+	for i := 0; i < ihl; i += 2 {
+		sum += uint32(binary.BigEndian.Uint16(packet[i : i+2]))
+	}
+
+	// Fold 32-bit sum to 16 bits
+	for sum > 0xFFFF {
+		sum = (sum & 0xFFFF) + (sum >> 16)
+	}
+
+	// Write one's complement
+	binary.BigEndian.PutUint16(packet[10:12], ^uint16(sum))
+}
+
+// recalculateTCPChecksum recalculates the TCP checksum.
+func recalculateTCPChecksum(packet []byte, ipHeaderLen int) {
+	tcpData := packet[ipHeaderLen:]
+	if len(tcpData) < 20 {
+		return
+	}
+
+	// Zero out the checksum
+	tcpData[16] = 0
+	tcpData[17] = 0
+
+	// Pseudo header: src IP, dst IP, zero, protocol, TCP length
+	srcIP := packet[12:16]
+	dstIP := packet[16:20]
+	tcpLen := len(tcpData)
+
+	var sum uint32
+	sum += uint32(srcIP[0])<<8 | uint32(srcIP[1])
+	sum += uint32(srcIP[2])<<8 | uint32(srcIP[3])
+	sum += uint32(dstIP[0])<<8 | uint32(dstIP[1])
+	sum += uint32(dstIP[2])<<8 | uint32(dstIP[3])
+	sum += 6 // TCP protocol
+	sum += uint32(tcpLen)
+
+	// TCP data
+	for i := 0; i < len(tcpData)-1; i += 2 {
+		sum += uint32(tcpData[i])<<8 | uint32(tcpData[i+1])
+	}
+	if len(tcpData)%2 == 1 {
+		sum += uint32(tcpData[len(tcpData)-1]) << 8
+	}
+
+	// Fold and complement
+	for sum > 0xFFFF {
+		sum = (sum & 0xFFFF) + (sum >> 16)
+	}
+
+	binary.BigEndian.PutUint16(tcpData[16:18], ^uint16(sum))
+}
+
+// recalculateUDPChecksum recalculates the UDP checksum.
+func recalculateUDPChecksum(packet []byte, ipHeaderLen int) {
+	udpData := packet[ipHeaderLen:]
+	if len(udpData) < 8 {
+		return
+	}
+
+	// Zero out the checksum
+	udpData[6] = 0
+	udpData[7] = 0
+
+	// Pseudo header
+	srcIP := packet[12:16]
+	dstIP := packet[16:20]
+	udpLen := len(udpData)
+
+	var sum uint32
+	sum += uint32(srcIP[0])<<8 | uint32(srcIP[1])
+	sum += uint32(srcIP[2])<<8 | uint32(srcIP[3])
+	sum += uint32(dstIP[0])<<8 | uint32(dstIP[1])
+	sum += uint32(dstIP[2])<<8 | uint32(dstIP[3])
+	sum += 17 // UDP protocol
+	sum += uint32(udpLen)
+
+	// UDP data
+	for i := 0; i < len(udpData)-1; i += 2 {
+		sum += uint32(udpData[i])<<8 | uint32(udpData[i+1])
+	}
+	if len(udpData)%2 == 1 {
+		sum += uint32(udpData[len(udpData)-1]) << 8
+	}
+
+	// Fold and complement
+	for sum > 0xFFFF {
+		sum = (sum & 0xFFFF) + (sum >> 16)
+	}
+
+	checksum := ^uint16(sum)
+	if checksum == 0 {
+		checksum = 0xFFFF // UDP checksum of 0 means no checksum
+	}
+	binary.BigEndian.PutUint16(udpData[6:8], checksum)
+}
+
+// recalculateICMPChecksum recalculates the ICMP checksum.
+func recalculateICMPChecksum(packet []byte, ipHeaderLen int) {
+	icmpData := packet[ipHeaderLen:]
+	if len(icmpData) < 8 {
+		return
+	}
+
+	// Zero out the checksum
+	icmpData[2] = 0
+	icmpData[3] = 0
+
+	var sum uint32
+	for i := 0; i < len(icmpData)-1; i += 2 {
+		sum += uint32(icmpData[i])<<8 | uint32(icmpData[i+1])
+	}
+	if len(icmpData)%2 == 1 {
+		sum += uint32(icmpData[len(icmpData)-1]) << 8
+	}
+
+	// Fold and complement
+	for sum > 0xFFFF {
+		sum = (sum & 0xFFFF) + (sum >> 16)
+	}
+
+	binary.BigEndian.PutUint16(icmpData[2:4], ^uint16(sum))
+}

--- a/internal/routing/nat_test.go
+++ b/internal/routing/nat_test.go
@@ -1,0 +1,387 @@
+package routing
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNATTable_NewNATTable(t *testing.T) {
+	exitIP := net.ParseIP("203.0.113.1")
+	table := NewNATTable(exitIP, 5*time.Minute)
+
+	assert.NotNil(t, table)
+	assert.Equal(t, uint16(NATPortMin), table.nextPort)
+}
+
+func TestNATTable_SetExitIP(t *testing.T) {
+	table := NewNATTable(nil, 5*time.Minute)
+
+	newIP := net.ParseIP("198.51.100.1")
+	table.SetExitIP(newIP)
+
+	table.mu.RLock()
+	defer table.mu.RUnlock()
+	assert.Equal(t, newIP, table.exitIP)
+}
+
+// buildTCPPacket creates a minimal TCP/IP packet for testing
+func buildTCPPacket(srcIP, dstIP net.IP, srcPort, dstPort uint16) []byte {
+	// Create 20-byte IP header + 20-byte TCP header (minimum)
+	packet := make([]byte, 40)
+
+	// IPv4 header (20 bytes)
+	packet[0] = 0x45 // Version 4, IHL 5 (20 bytes)
+	packet[1] = 0    // TOS
+	binary.BigEndian.PutUint16(packet[2:4], 40)  // Total length
+	binary.BigEndian.PutUint16(packet[4:6], 0)   // ID
+	binary.BigEndian.PutUint16(packet[6:8], 0)   // Flags/Fragment
+	packet[8] = 64                               // TTL
+	packet[9] = 6                                // Protocol (TCP)
+	packet[10] = 0                               // Checksum (will be calculated)
+	packet[11] = 0
+	copy(packet[12:16], srcIP.To4())
+	copy(packet[16:20], dstIP.To4())
+
+	// TCP header (20 bytes minimum)
+	binary.BigEndian.PutUint16(packet[20:22], srcPort) // Source port
+	binary.BigEndian.PutUint16(packet[22:24], dstPort) // Dest port
+	binary.BigEndian.PutUint32(packet[24:28], 0)       // Sequence
+	binary.BigEndian.PutUint32(packet[28:32], 0)       // Ack
+	packet[32] = 5 << 4                                // Data offset (5 = 20 bytes)
+	packet[33] = 0x02                                  // SYN flag
+	binary.BigEndian.PutUint16(packet[34:36], 65535)   // Window
+	binary.BigEndian.PutUint16(packet[36:38], 0)       // Checksum
+	binary.BigEndian.PutUint16(packet[38:40], 0)       // Urgent pointer
+
+	return packet
+}
+
+// buildUDPPacket creates a minimal UDP/IP packet for testing
+func buildUDPPacket(srcIP, dstIP net.IP, srcPort, dstPort uint16) []byte {
+	// Create 20-byte IP header + 8-byte UDP header
+	packet := make([]byte, 28)
+
+	// IPv4 header (20 bytes)
+	packet[0] = 0x45 // Version 4, IHL 5 (20 bytes)
+	packet[1] = 0    // TOS
+	binary.BigEndian.PutUint16(packet[2:4], 28)  // Total length
+	binary.BigEndian.PutUint16(packet[4:6], 0)   // ID
+	binary.BigEndian.PutUint16(packet[6:8], 0)   // Flags/Fragment
+	packet[8] = 64                               // TTL
+	packet[9] = 17                               // Protocol (UDP)
+	packet[10] = 0                               // Checksum (will be calculated)
+	packet[11] = 0
+	copy(packet[12:16], srcIP.To4())
+	copy(packet[16:20], dstIP.To4())
+
+	// UDP header (8 bytes)
+	binary.BigEndian.PutUint16(packet[20:22], srcPort) // Source port
+	binary.BigEndian.PutUint16(packet[22:24], dstPort) // Dest port
+	binary.BigEndian.PutUint16(packet[24:26], 8)       // Length
+	binary.BigEndian.PutUint16(packet[26:28], 0)       // Checksum
+
+	return packet
+}
+
+// buildICMPPacket creates a minimal ICMP/IP packet for testing
+func buildICMPPacket(srcIP, dstIP net.IP, icmpID uint16) []byte {
+	// Create 20-byte IP header + 8-byte ICMP header
+	packet := make([]byte, 28)
+
+	// IPv4 header (20 bytes)
+	packet[0] = 0x45 // Version 4, IHL 5 (20 bytes)
+	packet[1] = 0    // TOS
+	binary.BigEndian.PutUint16(packet[2:4], 28)  // Total length
+	binary.BigEndian.PutUint16(packet[4:6], 0)   // ID
+	binary.BigEndian.PutUint16(packet[6:8], 0)   // Flags/Fragment
+	packet[8] = 64                               // TTL
+	packet[9] = 1                                // Protocol (ICMP)
+	packet[10] = 0                               // Checksum (will be calculated)
+	packet[11] = 0
+	copy(packet[12:16], srcIP.To4())
+	copy(packet[16:20], dstIP.To4())
+
+	// ICMP header (8 bytes minimum)
+	packet[20] = 8 // Echo Request
+	packet[21] = 0 // Code
+	binary.BigEndian.PutUint16(packet[22:24], 0)       // Checksum
+	binary.BigEndian.PutUint16(packet[24:26], icmpID)  // ID
+	binary.BigEndian.PutUint16(packet[26:28], 1)       // Sequence
+
+	return packet
+}
+
+func TestNATTable_TranslateOutbound_TCP(t *testing.T) {
+	exitIP := net.ParseIP("203.0.113.1")
+	table := NewNATTable(exitIP, 5*time.Minute)
+
+	srcIP := net.ParseIP("10.99.0.2")
+	dstIP := net.ParseIP("8.8.8.8")
+	packet := buildTCPPacket(srcIP, dstIP, 12345, 80)
+
+	translated, err := table.TranslateOutbound(packet, "peer1")
+	require.NoError(t, err)
+	require.NotNil(t, translated)
+
+	// Verify source IP was changed to exit IP
+	newSrcIP := net.IP(translated[12:16])
+	assert.True(t, newSrcIP.Equal(exitIP.To4()), "Source IP should be exit IP")
+
+	// Verify destination IP unchanged
+	newDstIP := net.IP(translated[16:20])
+	assert.True(t, newDstIP.Equal(dstIP.To4()), "Destination IP should be unchanged")
+
+	// Verify NAT entry was created
+	entries, created, _ := table.Stats()
+	assert.Equal(t, 1, entries)
+	assert.Equal(t, uint64(1), created)
+}
+
+func TestNATTable_TranslateOutbound_UDP(t *testing.T) {
+	exitIP := net.ParseIP("203.0.113.1")
+	table := NewNATTable(exitIP, 5*time.Minute)
+
+	srcIP := net.ParseIP("10.99.0.2")
+	dstIP := net.ParseIP("8.8.8.8")
+	packet := buildUDPPacket(srcIP, dstIP, 54321, 53)
+
+	translated, err := table.TranslateOutbound(packet, "peer1")
+	require.NoError(t, err)
+	require.NotNil(t, translated)
+
+	// Verify source IP was changed to exit IP
+	newSrcIP := net.IP(translated[12:16])
+	assert.True(t, newSrcIP.Equal(exitIP.To4()), "Source IP should be exit IP")
+}
+
+func TestNATTable_TranslateOutbound_ICMP(t *testing.T) {
+	exitIP := net.ParseIP("203.0.113.1")
+	table := NewNATTable(exitIP, 5*time.Minute)
+
+	srcIP := net.ParseIP("10.99.0.2")
+	dstIP := net.ParseIP("8.8.8.8")
+	packet := buildICMPPacket(srcIP, dstIP, 1234)
+
+	translated, err := table.TranslateOutbound(packet, "peer1")
+	require.NoError(t, err)
+	require.NotNil(t, translated)
+
+	// Verify source IP was changed to exit IP
+	newSrcIP := net.IP(translated[12:16])
+	assert.True(t, newSrcIP.Equal(exitIP.To4()), "Source IP should be exit IP")
+}
+
+func TestNATTable_TranslateOutbound_ReuseEntry(t *testing.T) {
+	exitIP := net.ParseIP("203.0.113.1")
+	table := NewNATTable(exitIP, 5*time.Minute)
+
+	srcIP := net.ParseIP("10.99.0.2")
+	dstIP := net.ParseIP("8.8.8.8")
+	packet := buildTCPPacket(srcIP, dstIP, 12345, 80)
+
+	// First translation
+	translated1, err := table.TranslateOutbound(packet, "peer1")
+	require.NoError(t, err)
+	natPort1 := binary.BigEndian.Uint16(translated1[20:22])
+
+	// Second translation (same connection)
+	translated2, err := table.TranslateOutbound(packet, "peer1")
+	require.NoError(t, err)
+	natPort2 := binary.BigEndian.Uint16(translated2[20:22])
+
+	// Should reuse the same NAT port
+	assert.Equal(t, natPort1, natPort2)
+
+	// Only one entry should exist
+	entries, _, _ := table.Stats()
+	assert.Equal(t, 1, entries)
+}
+
+func TestNATTable_TranslateInbound_TCP(t *testing.T) {
+	exitIP := net.ParseIP("203.0.113.1")
+	table := NewNATTable(exitIP, 5*time.Minute)
+
+	// Create outbound packet to establish NAT entry
+	srcIP := net.ParseIP("10.99.0.2")
+	dstIP := net.ParseIP("8.8.8.8")
+	outPacket := buildTCPPacket(srcIP, dstIP, 12345, 80)
+
+	translated, err := table.TranslateOutbound(outPacket, "peer1")
+	require.NoError(t, err)
+
+	// Get the NAT port assigned
+	natPort := binary.BigEndian.Uint16(translated[20:22])
+
+	// Create inbound response packet
+	responsePacket := buildTCPPacket(dstIP, exitIP, 80, natPort)
+
+	// Translate inbound
+	peerName, inTranslated, err := table.TranslateInbound(responsePacket)
+	require.NoError(t, err)
+	assert.Equal(t, "peer1", peerName)
+
+	// Verify destination IP was restored to original source
+	newDstIP := net.IP(inTranslated[16:20])
+	assert.True(t, newDstIP.Equal(srcIP.To4()), "Destination should be original source IP")
+
+	// Verify destination port was restored
+	newDstPort := binary.BigEndian.Uint16(inTranslated[22:24])
+	assert.Equal(t, uint16(12345), newDstPort)
+}
+
+func TestNATTable_TranslateInbound_NoEntry(t *testing.T) {
+	exitIP := net.ParseIP("203.0.113.1")
+	table := NewNATTable(exitIP, 5*time.Minute)
+
+	// Create inbound packet without prior outbound
+	srcIP := net.ParseIP("8.8.8.8")
+	dstIP := net.ParseIP("203.0.113.1")
+	packet := buildTCPPacket(srcIP, dstIP, 80, 50000)
+
+	_, _, err := table.TranslateInbound(packet)
+	assert.Error(t, err)
+}
+
+func TestNATTable_Cleanup(t *testing.T) {
+	exitIP := net.ParseIP("203.0.113.1")
+	table := NewNATTable(exitIP, 10*time.Millisecond) // Very short timeout for testing
+
+	srcIP := net.ParseIP("10.99.0.2")
+	dstIP := net.ParseIP("8.8.8.8")
+	packet := buildTCPPacket(srcIP, dstIP, 12345, 80)
+
+	_, err := table.TranslateOutbound(packet, "peer1")
+	require.NoError(t, err)
+
+	// Verify entry exists
+	entries, _, _ := table.Stats()
+	assert.Equal(t, 1, entries)
+
+	// Wait for entry to expire
+	time.Sleep(20 * time.Millisecond)
+
+	// Cleanup should remove the entry
+	removed := table.Cleanup()
+	assert.Equal(t, 1, removed)
+
+	entries, _, expired := table.Stats()
+	assert.Equal(t, 0, entries)
+	assert.Equal(t, uint64(1), expired)
+}
+
+func TestNATTable_PortAllocation(t *testing.T) {
+	exitIP := net.ParseIP("203.0.113.1")
+	table := NewNATTable(exitIP, 5*time.Minute)
+
+	srcIP := net.ParseIP("10.99.0.2")
+	dstIP := net.ParseIP("8.8.8.8")
+
+	// Create multiple connections (different destination ports)
+	var ports []uint16
+	for i := 0; i < 10; i++ {
+		packet := buildTCPPacket(srcIP, dstIP, uint16(12345+i), uint16(80+i))
+		translated, err := table.TranslateOutbound(packet, "peer1")
+		require.NoError(t, err)
+		natPort := binary.BigEndian.Uint16(translated[20:22])
+		ports = append(ports, natPort)
+	}
+
+	// All ports should be unique
+	portSet := make(map[uint16]bool)
+	for _, p := range ports {
+		assert.False(t, portSet[p], "Duplicate NAT port allocated: %d", p)
+		portSet[p] = true
+	}
+
+	entries, _, _ := table.Stats()
+	assert.Equal(t, 10, entries)
+}
+
+func TestNATTable_TranslateOutbound_TooShort(t *testing.T) {
+	exitIP := net.ParseIP("203.0.113.1")
+	table := NewNATTable(exitIP, 5*time.Minute)
+
+	// Packet too short
+	_, err := table.TranslateOutbound([]byte{0x45, 0x00}, "peer1")
+	assert.Error(t, err)
+}
+
+func TestNATTable_UnsupportedProtocol(t *testing.T) {
+	exitIP := net.ParseIP("203.0.113.1")
+	table := NewNATTable(exitIP, 5*time.Minute)
+
+	// Create packet with unsupported protocol (GRE = 47)
+	packet := make([]byte, 24)
+	packet[0] = 0x45 // Version 4, IHL 5
+	binary.BigEndian.PutUint16(packet[2:4], 24)
+	packet[9] = 47 // GRE protocol
+	copy(packet[12:16], net.ParseIP("10.99.0.2").To4())
+	copy(packet[16:20], net.ParseIP("8.8.8.8").To4())
+
+	_, err := table.TranslateOutbound(packet, "peer1")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported protocol")
+}
+
+func TestConnectionKey(t *testing.T) {
+	srcIP := net.ParseIP("10.99.0.2")
+	dstIP := net.ParseIP("8.8.8.8")
+
+	key := connectionKey(6, srcIP, 12345, dstIP, 80)
+	assert.Equal(t, "6:10.99.0.2:12345:8.8.8.8:80", key)
+}
+
+func TestRecalculateIPChecksum(t *testing.T) {
+	// Build a packet
+	srcIP := net.ParseIP("10.99.0.1").To4()
+	dstIP := net.ParseIP("10.99.0.2").To4()
+	packet := BuildIPv4Packet(srcIP, dstIP, ProtoUDP, []byte("test"))
+
+	// Modify source IP
+	copy(packet[12:16], net.ParseIP("192.168.1.1").To4())
+
+	// Recalculate checksum
+	recalculateIPChecksum(packet)
+
+	// Verify checksum is valid (should be 0 or 0xFFFF when recalculated with checksum field included)
+	verify := CalculateIPv4Checksum(packet[:20])
+	assert.True(t, verify == 0 || verify == 0xFFFF, "Checksum should be valid")
+}
+
+func BenchmarkNATTranslateOutbound(b *testing.B) {
+	exitIP := net.ParseIP("203.0.113.1")
+	table := NewNATTable(exitIP, 5*time.Minute)
+
+	srcIP := net.ParseIP("10.99.0.2")
+	dstIP := net.ParseIP("8.8.8.8")
+	packet := buildTCPPacket(srcIP, dstIP, 12345, 80)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = table.TranslateOutbound(packet, "peer1")
+	}
+}
+
+func BenchmarkNATTranslateInbound(b *testing.B) {
+	exitIP := net.ParseIP("203.0.113.1")
+	table := NewNATTable(exitIP, 5*time.Minute)
+
+	srcIP := net.ParseIP("10.99.0.2")
+	dstIP := net.ParseIP("8.8.8.8")
+	outPacket := buildTCPPacket(srcIP, dstIP, 12345, 80)
+
+	translated, _ := table.TranslateOutbound(outPacket, "peer1")
+	natPort := binary.BigEndian.Uint16(translated[20:22])
+
+	responsePacket := buildTCPPacket(dstIP, exitIP, 80, natPort)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = table.TranslateInbound(responsePacket)
+	}
+}

--- a/internal/routing/router.go
+++ b/internal/routing/router.go
@@ -121,10 +121,11 @@ func (r *Router) ListRoutes() map[string]string {
 
 // PacketInfo contains parsed information from an IPv4 packet.
 type PacketInfo struct {
-	SrcIP    net.IP
-	DstIP    net.IP
-	Protocol uint8
-	Payload  []byte
+	SrcIP     net.IP
+	DstIP     net.IP
+	Protocol  uint8
+	HeaderLen int // IP header length in bytes
+	Payload   []byte
 }
 
 // BuildIPv4Packet constructs a minimal IPv4 packet.
@@ -191,9 +192,10 @@ func ParseIPv4Packet(packet []byte) (*PacketInfo, error) {
 	}
 
 	info := &PacketInfo{
-		SrcIP:    net.IP(packet[12:16]),
-		DstIP:    net.IP(packet[16:20]),
-		Protocol: packet[9],
+		SrcIP:     net.IP(packet[12:16]),
+		DstIP:     net.IP(packet[16:20]),
+		Protocol:  packet[9],
+		HeaderLen: ihl,
 	}
 
 	if len(packet) > ihl {

--- a/pkg/proto/messages.go
+++ b/pkg/proto/messages.go
@@ -66,7 +66,14 @@ type HeartbeatResponse struct {
 
 // PeerListResponse contains the list of all mesh peers.
 type PeerListResponse struct {
-	Peers []Peer `json:"peers"`
+	Peers           []Peer           `json:"peers"`
+	NetworkSettings *NetworkSettings `json:"network_settings,omitempty"`
+}
+
+// NetworkSettings contains centralized network configuration from the server.
+type NetworkSettings struct {
+	ExitNodePeer string   `json:"exit_node_peer"` // Which peer is the exit node (empty = disabled)
+	Exceptions   []string `json:"exceptions"`     // CIDRs for exit bypass and tunnel connection skip
 }
 
 // DNSRecord represents a hostname to IP mapping.


### PR DESCRIPTION
## Summary
- Implement exit node functionality allowing peers to route all external traffic through a designated exit node
- Add centralized configuration via admin panel (not per-peer config)
- Support network exceptions (CIDRs) that bypass exit routing AND tunnel connection attempts
- Implement NAT/masquerade on exit node so external servers see exit node's public IP

## Changes

### New Files
- `internal/routing/nat.go` - NAT table implementation with connection tracking for TCP, UDP, ICMP
- `internal/routing/exit.go` - Exit handler for processing exit traffic from peers
- `internal/routing/nat_test.go` - Comprehensive tests for NAT functionality

### Protocol & API
- Added `NetworkSettings` struct to `PeerListResponse` for centralized distribution
- Added GET/POST `/admin/api/network-settings` endpoints
- Server validates exit node peer exists before accepting setting

### Admin UI
- Added Network Settings section with exit node dropdown and exceptions textarea
- Pre-populated with sensible default exception CIDRs (Tailscale, private networks, etc.)

### Routing & Networking
- Added `ProtoExitPacket` protocol type for exit traffic
- Forwarder routes non-mesh traffic to designated exit node
- Negotiator filters peer addresses based on exception CIDRs

## Test plan
- [x] All existing tests pass
- [x] NAT table tests (translation, cleanup, port allocation, checksums)
- [x] Exit routing tests (forwarding, exception bypassing, packet handling)
- [x] Network settings API tests (GET/POST, clearing, inclusion in responses)
- [x] Negotiator exception CIDR tests (filtering, probing with exceptions)
- [ ] Manual testing with two peers and exit node configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)