### PR TITLE
Close idle HTTP connections before re-registering after IP change

### DIFF
--- a/cmd/tunnelmesh/main.go
+++ b/cmd/tunnelmesh/main.go
@@ -1399,6 +1399,10 @@ func heartbeatLoop(ctx context.Context, client *coord.Client, name, pubKeyEncode
 					Strs("old_private", lastPrivateIPs).
 					Strs("new_private", privateIPs).
 					Msg("IP addresses changed, re-registering...")
+
+				// Close stale connections from the old network
+				client.CloseIdleConnections()
+
 				if _, regErr := client.Register(name, pubKeyEncoded, publicIPs, privateIPs, sshPort, behindNAT); regErr != nil {
 					log.Error().Err(regErr).Msg("failed to re-register after IP change")
 				} else {

--- a/internal/coord/client.go
+++ b/internal/coord/client.go
@@ -200,3 +200,9 @@ func (c *Client) JWTToken() string {
 func (c *Client) BaseURL() string {
 	return c.baseURL
 }
+
+// CloseIdleConnections closes any idle connections in the HTTP client pool.
+// This should be called after network changes to prevent stale connections.
+func (c *Client) CloseIdleConnections() {
+	c.client.CloseIdleConnections()
+}


### PR DESCRIPTION
## Summary
- Close stale HTTP connections before re-registering after network change
- Prevents hanging when switching networks (VPN to regular, WiFi to mobile, etc.)

## Problem
When the network changes, the HTTP client's connection pool may contain stale connections from the old network. When trying to re-register after detecting an IP change, these stale connections can hang even though they'll eventually timeout after 30 seconds.

Example scenario:
1. User is on VPN (public IP: 104.248.26.224)
2. User disconnects from VPN (new public IP: 86.169.165.186)
3. Heartbeat loop detects IP change and tries to re-register
4. HTTP client tries to reuse a pooled connection from the old network
5. Connection hangs until 30-second timeout

## Solution
Added `CloseIdleConnections()` method to `coord.Client` and call it before re-registering after detecting an IP change. This forces the HTTP client to establish fresh connections through the new network path.

## Test plan
- [x] All tests pass
- [ ] Test network switching scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)