### PR TITLE
Close idle HTTP connections in networkChangeLoop before re-registering

### DIFF
--- a/cmd/tunnelmesh/main.go
+++ b/cmd/tunnelmesh/main.go
@@ -1013,6 +1013,9 @@ func networkChangeLoop(ctx context.Context, events <-chan netmon.Event,
 				Bool("behind_nat", behindNAT).
 				Msg("updated local IPs")
 
+			// Close stale HTTP connections from the old network before re-registering
+			client.CloseIdleConnections()
+
 			// Re-register with coordination server
 			resp, err := client.Register(cfg.Name, pubKeyEncoded, publicIPs, privateIPs, cfg.SSHPort, behindNAT)
 			if err != nil {


### PR DESCRIPTION
## Summary
- Call `CloseIdleConnections()` in `networkChangeLoop` before re-registering
- Prevents stale connection hangs when network changes

## Problem
When switching networks (e.g., WiFi to mobile hotspot), the `networkChangeLoop` was trying to re-register with the coordination server, but the HTTP client might have stale connections from the old network. This could cause the re-register call to hang.

This is the same issue fixed in PR #22 for the heartbeat loop, but the `networkChangeLoop` was missing the same fix.

## Test plan
- [x] All tests pass
- [ ] Test network switch (WiFi to hotspot) and verify immediate IP update

🤖 Generated with [Claude Code](https://claude.com/claude-code)