### PR TITLE
Skip public IP probe when peer is not connectable (behind NAT)

### DIFF
--- a/internal/negotiate/negotiator.go
+++ b/internal/negotiate/negotiator.go
@@ -60,14 +60,16 @@ func (p *PeerInfo) BestAddress() string {
 
 // AllAddresses returns all possible addresses for this peer.
 // Private IPs are listed first (LAN connectivity preferred), then public IPs.
+// If Connectable is false (peer is behind NAT), public IP is excluded since
+// the TCP probe might succeed (router responds) but SSH will fail without port forwarding.
 func (p *PeerInfo) AllAddresses() []string {
 	var addrs []string
 	// Private IPs first (same LAN = lowest latency)
 	for _, ip := range p.PrivateIPs {
 		addrs = append(addrs, fmt.Sprintf("%s:%d", ip, p.SSHPort))
 	}
-	// Public IP second
-	if p.PublicIP != "" {
+	// Public IP second - only if peer is connectable (has port forwarding or public IP)
+	if p.PublicIP != "" && p.Connectable {
 		addrs = append(addrs, fmt.Sprintf("%s:%d", p.PublicIP, p.SSHPort))
 	}
 	return addrs

--- a/internal/negotiate/negotiator_test.go
+++ b/internal/negotiate/negotiator_test.go
@@ -166,10 +166,10 @@ func TestNegotiator_NegotiateFallbackReverse(t *testing.T) {
 	ctx := context.Background()
 	peer := &PeerInfo{
 		ID:          "peer1",
-		PublicIP:    "192.0.2.1", // TEST-NET address, not routable
-		PrivateIPs:  []string{"10.0.0.99"},
-		SSHPort:     2222,
-		Connectable: true, // Peer can accept incoming connections
+		PublicIP:    "127.0.0.1", // Use localhost with closed port
+		PrivateIPs:  []string{"127.0.0.1"},
+		SSHPort:     59998, // Port that should not be listening
+		Connectable: true,  // Peer can accept incoming connections
 	}
 
 	// When no direct connection works and peer is connectable, should recommend reverse


### PR DESCRIPTION
## Summary
- Don't probe public IP when `Connectable: false`
- Prevents hanging SSH connections to unreachable NAT'd peers
- Fixed flaky test using TEST-NET IP

## Problem
When a peer is behind NAT (`Connectable: false`), the negotiator was still probing the public IP. The TCP probe might succeed (router responds to SYN for connection tracking) but the actual SSH connection hangs because there's no port forwarding.

From the logs:
```
probe succeeded addr=86.169.165.186:2227 latency=122.23975
selected direct connection address=86.169.165.186:2227 strategy=direct
connecting to peer via direct SSH addr=86.169.165.186:2227
[then silence... SSH hangs, no tunnel established]
forward packet failed error="no tunnel for peer roku"
```

## Solution
In `AllAddresses()`, only include the public IP if `Connectable: true`. When `Connectable: false`, only private IPs are probed. If private IPs fail, the negotiator falls back to relay (which is the correct behavior for NAT'd peers).

## Test plan
- [x] All tests pass
- [ ] Test connection to peer behind NAT - should use relay instead of hanging on public IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)