### PR TITLE
Add relay request notifications via heartbeat

### DIFF
--- a/internal/coord/client_test.go
+++ b/internal/coord/client_test.go
@@ -82,7 +82,7 @@ func TestClient_Heartbeat(t *testing.T) {
 	require.NoError(t, err)
 
 	// Heartbeat
-	err = client.Heartbeat("mynode", "SHA256:key")
+	_, err = client.Heartbeat("mynode", "SHA256:key")
 	assert.NoError(t, err)
 }
 
@@ -102,7 +102,7 @@ func TestClient_HeartbeatNotFound(t *testing.T) {
 	client := NewClient(ts.URL, "test-token")
 
 	// Heartbeat without registering should return ErrPeerNotFound
-	err = client.Heartbeat("unknown-node", "SHA256:key")
+	_, err = client.Heartbeat("unknown-node", "SHA256:key")
 	assert.ErrorIs(t, err, ErrPeerNotFound)
 }
 

--- a/internal/coord/relay.go
+++ b/internal/coord/relay.go
@@ -40,6 +40,23 @@ func newRelayManager() *relayManager {
 	}
 }
 
+// GetPendingRequestsFor returns the list of peers waiting on relay for the given peer.
+// For example, if "oldie" is waiting on relay for "roku", calling GetPendingRequestsFor("roku")
+// returns ["oldie"].
+func (r *relayManager) GetPendingRequestsFor(peerName string) []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var requests []string
+	suffix := "->" + peerName
+	for key, conn := range r.pending {
+		if len(key) > len(suffix) && key[len(key)-len(suffix):] == suffix {
+			requests = append(requests, conn.peerName)
+		}
+	}
+	return requests
+}
+
 // setupRelayRoutes registers the relay WebSocket endpoint.
 func (s *Server) setupRelayRoutes() {
 	if s.relay == nil {

--- a/internal/coord/server.go
+++ b/internal/coord/server.go
@@ -354,6 +354,12 @@ func (s *Server) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := proto.HeartbeatResponse{OK: true}
+
+	// Check if any peers are waiting on relay for this peer
+	if s.relay != nil {
+		resp.RelayRequests = s.relay.GetPendingRequestsFor(req.Name)
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(resp)
 }

--- a/pkg/proto/messages.go
+++ b/pkg/proto/messages.go
@@ -61,7 +61,8 @@ type HeartbeatRequest struct {
 
 // HeartbeatResponse is returned after successful heartbeat.
 type HeartbeatResponse struct {
-	OK bool `json:"ok"`
+	OK            bool     `json:"ok"`
+	RelayRequests []string `json:"relay_requests,omitempty"` // Peers waiting on relay for us
 }
 
 // PeerListResponse contains the list of all mesh peers.


### PR DESCRIPTION
## Summary
- Notify peers via heartbeat when someone is waiting for them on relay
- Peer automatically connects to relay when notified
- Fixes relay pairing when only one side decides to use relay

## Problem
Previously, relay pairing required both peers to independently decide to use relay:
1. Peer A connects to relay for B, waits
2. B must also decide to use relay and connect
3. If B doesn't (e.g., B's negotiation succeeded differently), A times out

## Solution
Now the coordination server notifies peers via heartbeat:

1. Peer A connects to relay for B → server tracks "A waiting for B"
2. B sends heartbeat → response includes `relay_requests: ["A"]`
3. B sees the notification and connects to relay for A
4. Server pairs them → relay works!

### Protocol Change
`HeartbeatResponse` now includes:
```json
{
  "ok": true,
  "relay_requests": ["oldie"]  // peers waiting on relay for us
}
```

### Flow
```
A: direct failed → connect to relay for B
Server: records "A->B" pending
B: heartbeat
Server: response includes relay_requests=["A"]
B: sees notification → connect to relay for A
Server: pairs A and B → bridge established
```

## Test plan
- [x] All tests pass
- [ ] Test relay connection where only one side initially uses relay

🤖 Generated with [Claude Code](https://claude.com/claude-code)