### PR TITLE
Fix connection race condition and remove alpha ordering

### DIFF
--- a/internal/peer/discovery_test.go
+++ b/internal/peer/discovery_test.go
@@ -91,50 +91,66 @@ func TestMeshNode_EstablishTunnel_NoTransportNegotiator(t *testing.T) {
 
 	// Should not panic, just return early
 	ctx := context.Background()
-	node.EstablishTunnel(ctx, peer, false)
+	node.EstablishTunnel(ctx, peer)
 	// No assertions needed - just verify it doesn't panic
 }
 
-func TestMeshNode_EstablishTunnel_AlphaOrdering(t *testing.T) {
-	// Test that alpha ordering works correctly
-	// When our name > peer name, we should wait for peer to initiate
-
-	tests := []struct {
-		name                string
-		myName              string
-		peerName            string
-		bypassAlphaOrdering bool
-		shouldSkip          bool // True if we should skip due to alpha ordering
-	}{
-		{
-			name:       "my name comes first alphabetically - should connect",
-			myName:     "alice",
-			peerName:   "bob",
-			shouldSkip: false,
-		},
-		{
-			name:       "my name comes second alphabetically - should skip",
-			myName:     "bob",
-			peerName:   "alice",
-			shouldSkip: true,
-		},
-		{
-			name:                "my name comes second but bypass enabled - should connect",
-			myName:              "bob",
-			peerName:            "alice",
-			bypassAlphaOrdering: true,
-			shouldSkip:          false,
+func TestMeshNode_ConnectingState(t *testing.T) {
+	// Test that connecting state tracking prevents duplicate connection attempts
+	identity := &PeerIdentity{
+		Name: "test-node",
+		Config: &config.PeerConfig{
+			Name: "test-node",
 		},
 	}
+	client := coord.NewClient("http://localhost:8080", "test-token")
+	node := NewMeshNode(identity, client)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// We test the alpha ordering condition directly
-			// This is the same condition used in EstablishTunnel
-			shouldSkipDueToAlpha := tt.myName > tt.peerName && !tt.bypassAlphaOrdering
-			assert.Equal(t, tt.shouldSkip, shouldSkipDueToAlpha)
-		})
+	// Initially not connecting
+	assert.False(t, node.IsConnecting("peer1"))
+
+	// Set connecting - should succeed
+	assert.True(t, node.SetConnecting("peer1"))
+	assert.True(t, node.IsConnecting("peer1"))
+
+	// Try to set connecting again - should fail (already connecting)
+	assert.False(t, node.SetConnecting("peer1"))
+
+	// Clear connecting
+	node.ClearConnecting("peer1")
+	assert.False(t, node.IsConnecting("peer1"))
+
+	// Can set connecting again after clearing
+	assert.True(t, node.SetConnecting("peer1"))
+	assert.True(t, node.IsConnecting("peer1"))
+}
+
+func TestMeshNode_ConnectingState_MultiplePeers(t *testing.T) {
+	// Test that connecting state is tracked per-peer
+	identity := &PeerIdentity{
+		Name: "test-node",
+		Config: &config.PeerConfig{
+			Name: "test-node",
+		},
 	}
+	client := coord.NewClient("http://localhost:8080", "test-token")
+	node := NewMeshNode(identity, client)
+
+	// Can connect to multiple peers simultaneously
+	assert.True(t, node.SetConnecting("peer1"))
+	assert.True(t, node.SetConnecting("peer2"))
+	assert.True(t, node.SetConnecting("peer3"))
+
+	// All are connecting
+	assert.True(t, node.IsConnecting("peer1"))
+	assert.True(t, node.IsConnecting("peer2"))
+	assert.True(t, node.IsConnecting("peer3"))
+
+	// Clear one doesn't affect others
+	node.ClearConnecting("peer2")
+	assert.True(t, node.IsConnecting("peer1"))
+	assert.False(t, node.IsConnecting("peer2"))
+	assert.True(t, node.IsConnecting("peer3"))
 }
 
 func TestMeshNode_RunPeerDiscovery_ContextCancel(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add connecting state tracking to prevent duplicate connection attempts
- Remove alpha ordering: both peers now race to connect, first wins
- Discovery loop now checks `IsConnecting()` before spawning goroutines
- `EstablishTunnel` uses `SetConnecting`/`ClearConnecting` with defer cleanup
- Check for existing tunnel after negotiation to handle race gracefully

## Problem
When trying to establish a tunnel to a peer behind NAT, multiple discovery cycles would spawn parallel `EstablishTunnel` goroutines for the same peer. This caused:
1. Duplicate connection attempts (visible in logs as interleaved "attempt=1", "attempt=2" from different goroutines)
2. Prevented proper transport fallback (UDP → SSH → Relay) because new goroutines kept starting fresh from UDP
3. Wasted resources with redundant handshake attempts

## Solution
1. **Connecting state tracking**: Added `connecting` map to `MeshNode` with `SetConnecting`/`ClearConnecting`/`IsConnecting` methods
2. **Race prevention**: Discovery now skips peers with connection attempts already in progress
3. **Removed alpha ordering**: Both peers can initiate connections, first successful one wins
4. **Graceful race handling**: After negotiation succeeds, check if peer already established tunnel and close ours if so

## Test plan
- [x] All unit tests pass
- [x] Linter passes
- [ ] Deploy and verify single connection attempt per peer
- [ ] Verify transport fallback works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)