### PR TITLE
Fix UDP hole-punching with bidirectional coordination and cancel mechanism

### DIFF
--- a/cmd/tunnelmesh/main.go
+++ b/cmd/tunnelmesh/main.go
@@ -648,6 +648,7 @@ func runJoinWithConfig(ctx context.Context, cfg *config.PeerConfig) error {
 
 			udpTransport, err := udptransport.New(udptransport.Config{
 				Port:           cfg.SSHPort + 1, // Use SSH port + 1 for UDP
+				LocalPeerName:  cfg.Name,
 				StaticPrivate:  privKey,
 				StaticPublic:   pubKey,
 				CoordServerURL: cfg.Server,

--- a/internal/coord/server.go
+++ b/internal/coord/server.go
@@ -384,6 +384,11 @@ func (s *Server) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		resp.RelayRequests = s.relay.GetPendingRequestsFor(req.Name)
 	}
 
+	// Check if any peers are waiting to hole-punch with this peer
+	if s.holePunch != nil {
+		resp.HolePunchRequests = s.holePunch.GetPendingHolePunches(req.Name)
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(resp)
 }

--- a/internal/peer/ssh.go
+++ b/internal/peer/ssh.go
@@ -38,6 +38,9 @@ func (m *MeshNode) handleSSHConnection(ctx context.Context, conn transport.Conne
 		Str("transport", string(conn.Type())).
 		Msg("incoming SSH connection")
 
+	// Cancel any outbound connection attempt to this peer
+	m.CancelOutboundConnection(peerName)
+
 	// Wrap connection as a tunnel
 	tun := tunnel.NewTunnelFromTransport(conn)
 

--- a/internal/peer/udp.go
+++ b/internal/peer/udp.go
@@ -38,6 +38,9 @@ func (m *MeshNode) handleUDPConnection(ctx context.Context, conn transport.Conne
 		Str("transport", string(conn.Type())).
 		Msg("incoming UDP connection")
 
+	// Cancel any outbound connection attempt to this peer
+	m.CancelOutboundConnection(peerName)
+
 	// Wrap connection as a tunnel
 	tun := tunnel.NewTunnelFromTransport(conn)
 

--- a/pkg/proto/messages.go
+++ b/pkg/proto/messages.go
@@ -65,9 +65,10 @@ type HeartbeatRequest struct {
 
 // HeartbeatResponse is returned after successful heartbeat.
 type HeartbeatResponse struct {
-	OK            bool     `json:"ok"`
-	RelayRequests []string `json:"relay_requests,omitempty"` // Peers waiting on relay for us
-	Reconnect     bool     `json:"reconnect,omitempty"`      // Signal to reconnect all tunnels
+	OK                bool     `json:"ok"`
+	RelayRequests     []string `json:"relay_requests,omitempty"`      // Peers waiting on relay for us
+	HolePunchRequests []string `json:"hole_punch_requests,omitempty"` // Peers wanting to UDP hole-punch with us
+	Reconnect         bool     `json:"reconnect,omitempty"`           // Signal to reconnect all tunnels
 }
 
 // RelayStatusResponse contains pending relay requests for a peer.


### PR DESCRIPTION
## Summary
- Fixed UDP hole-punching to use bidirectional coordination (both peers send packets simultaneously)
- Added mechanism to cancel outbound connections when inbound succeeds
- Added integration tests for both behaviors

## Problem
UDP hole-punching was failing because it was one-sided - only the initiating peer sent packets. For NAT traversal to work, both peers need to send packets to each other simultaneously to "punch" through their respective NATs.

Additionally, when both peers race to connect, the slower connection could succeed after the faster one was already established, potentially causing duplicate tunnels.

## Solution

### Bidirectional Hole-Punch Coordination
1. When peer A tries to hole-punch to peer B, the server records this request
2. When peer B sends its next heartbeat, it receives notification that peer A wants to hole-punch
3. Peer B then initiates a connection attempt back to peer A
4. Both peers are now sending packets to each other, enabling NAT traversal

### Cancel Outbound on Inbound Success
1. When starting an outbound connection, store a cancel function
2. When an inbound connection succeeds, cancel any pending outbound to the same peer
3. This prevents duplicate tunnels and wasted connection attempts

## Test plan
- [x] All existing tests pass
- [x] Added integration test for bidirectional hole-punch coordination
- [x] Added tests for outbound cancellation mechanism
- [x] Race detector passes
- [ ] Test with two NAT'd peers

🤖 Generated with [Claude Code](https://claude.com/claude-code)