### PR TITLE
Add debug logging for UDP data packet flow

### DIFF
--- a/internal/transport/udp/session.go
+++ b/internal/transport/udp/session.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/rs/zerolog/log"
 )
 
 // SessionState represents the current state of a UDP session.
@@ -171,10 +173,17 @@ func (s *Session) Send(data []byte) error {
 	copy(packet[len(headerBytes):], ciphertext)
 
 	// Send
-	_, err := s.conn.WriteToUDP(packet, remoteAddr)
+	n, err := s.conn.WriteToUDP(packet, remoteAddr)
 	if err != nil {
 		return err
 	}
+
+	log.Debug().
+		Str("peer", s.peerName).
+		Str("remote", remoteAddr.String()).
+		Int("data_len", len(data)).
+		Int("packet_len", n).
+		Msg("UDP data packet sent")
 
 	s.lastSend = time.Now()
 	s.bytesOut.Add(uint64(len(data)))

--- a/internal/transport/udp/transport.go
+++ b/internal/transport/udp/transport.go
@@ -292,8 +292,19 @@ func (t *Transport) handleDataPacket(header *PacketHeader, ciphertext []byte, re
 	t.mu.RUnlock()
 
 	if !ok {
-		return // Unknown session
+		log.Debug().
+			Uint32("receiver_index", header.Receiver).
+			Str("from", remoteAddr.String()).
+			Int("ciphertext_len", len(ciphertext)).
+			Msg("data packet for unknown session")
+		return
 	}
+
+	log.Debug().
+		Str("peer", session.PeerName()).
+		Uint32("receiver_index", header.Receiver).
+		Int("ciphertext_len", len(ciphertext)).
+		Msg("UDP data packet received")
 
 	// Update remote address (NAT roaming)
 	currentAddr := session.RemoteAddr()


### PR DESCRIPTION
## Summary
- Add debug logging when UDP data packets are sent and received
- Log when packets arrive for unknown sessions (helps diagnose session lookup failures)

## Problem
Ping timeouts occurring even though tunnels are established and healthy. Need visibility into packet flow.

## Changes
- `session.go`: Log peer, address, and size when sending data packets
- `transport.go`: Log when data packets are received and routed to sessions
- Log when packets arrive for unknown sessions (potential issue indicator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)