### PR TITLE
Fix route delete loop to check output for 'not in table'

### DIFF
--- a/internal/tun/device.go
+++ b/internal/tun/device.go
@@ -136,12 +136,13 @@ func (d *Device) configureDarwin() error {
 	for i := 0; i < 50; i++ { // Max 50 attempts to avoid infinite loop
 		cmd = exec.Command("route", "delete", "-net", routeNet)
 		out, err := cmd.CombinedOutput()
-		if err != nil {
-			// No more routes to delete
+		outStr := strings.TrimSpace(string(out))
+		// Check both error and output - macOS route delete returns 0 even when route doesn't exist
+		if err != nil || strings.Contains(outStr, "not in table") {
 			log.Debug().Int("deleted", i).Msg("cleared existing network routes")
 			break
 		}
-		log.Debug().Str("output", strings.TrimSpace(string(out))).Msg("deleted existing route")
+		log.Debug().Str("output", outStr).Msg("deleted existing route")
 	}
 
 	// Also flush the route cache for this network to clear cloned host routes


### PR DESCRIPTION
## Summary
Fix the route delete loop to properly detect when there are no more routes to delete.

## Problem
macOS `route delete` returns exit code 0 even when the route doesn't exist - it just prints "not in table" to stderr. This caused the loop to run all 50 iterations unnecessarily.

## Solution
Check the output string for "not in table" in addition to the error code.

## Test plan
- [x] Build passes
- [x] Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)