### PR TITLE
Remove aggressive route flush that broke system routing

### DIFF
--- a/internal/tun/device.go
+++ b/internal/tun/device.go
@@ -145,13 +145,6 @@ func (d *Device) configureDarwin() error {
 		log.Debug().Str("output", outStr).Msg("deleted existing route")
 	}
 
-	// Also flush the route cache for this network to clear cloned host routes
-	// This removes cached entries like "10.99.0.2 -> utun5" that can override our route
-	cmd = exec.Command("route", "-n", "flush")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		log.Debug().Str("output", string(out)).Msg("route flush (may fail on some systems)")
-	}
-
 	// Add our route
 	cmd = exec.Command("route", "add", "-net", routeNet, "-interface", d.name)
 	if out, err := cmd.CombinedOutput(); err != nil {


### PR DESCRIPTION
## Summary
- Removed `route -n flush` command from macOS TUN device configuration
- This command was flushing the entire system route cache instead of just mesh network routes

## Problem
The `route -n flush` command was intended to clear cached routes for the mesh network, but it actually flushed ALL cached routes from the system routing table. This caused complete loss of networking on macOS when the service started.

## Solution
Removed the flush command entirely. The existing route deletion loop (lines 136-146) already properly handles removing conflicting routes for the specific mesh network CIDR (e.g., `10.99.0.0/16`), making the aggressive flush unnecessary.

## Test plan
- [x] All tests pass
- [ ] Verify TUN device setup doesn't break system routing
- [ ] Verify mesh network routes are still properly configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)