### PR TITLE
Fix connection race condition causing one-way traffic

### DIFF
--- a/internal/peer/ssh.go
+++ b/internal/peer/ssh.go
@@ -42,6 +42,18 @@ func (m *MeshNode) handleSSHConnection(ctx context.Context, conn transport.Conne
 	// Cancel any outbound connection attempt to this peer
 	m.CancelOutboundConnection(peerName)
 
+	// If we already have a healthy tunnel to this peer, reject the incoming connection
+	// to avoid race conditions where both peers connect simultaneously
+	if existing, ok := m.tunnelMgr.Get(peerName); ok {
+		if hc, canCheck := existing.(tunnel.HealthChecker); canCheck && hc.IsHealthy() {
+			log.Debug().
+				Str("peer", peerName).
+				Msg("already have healthy tunnel, rejecting incoming connection")
+			conn.Close()
+			return
+		}
+	}
+
 	// Fetch peer info from coordination server to get mesh IP and add route
 	// This ensures routing works immediately, without waiting for next discovery cycle
 	m.ensurePeerRoute(peerName)


### PR DESCRIPTION
## Summary
- Reject incoming connections if we already have a healthy tunnel to the peer
- Applied to both SSH and UDP handlers

## Problem
When both peers connect to each other simultaneously, two separate connections are created:
- Peer A's outbound to Peer B
- Peer B's outbound to Peer A

When Peer B's connection arrives at Peer A, `TunnelManager.Add` closes the existing tunnel (Peer A's outbound) and replaces it with Peer B's inbound. However, `HandleTunnel` was already reading from the old tunnel, which is now closed.

This results in:
- Peer A writes to tunnel (Peer B's connection)
- Peer B's `HandleTunnel` reads from its own outbound connection (different tunnel!)
- Packets flow only one direction

## Solution
Before accepting an incoming connection, check if we already have a healthy tunnel to that peer. If so, reject the incoming connection to preserve the working tunnel.

## Test plan
- [x] All tests pass
- [ ] Test bidirectional ping between two peers
- [ ] Verify simultaneous connection attempts result in working tunnels

🤖 Generated with [Claude Code](https://claude.com/claude-code)