### PR TITLE
Add rekey-required message for stale UDP sessions

### DIFF
--- a/internal/transport/udp/udp_test.go
+++ b/internal/transport/udp/udp_test.go
@@ -579,6 +579,43 @@ func TestKeepalivePacket(t *testing.T) {
 }
 
 // =============================================================================
+// Rekey Required Packet Tests
+// =============================================================================
+
+func TestRekeyRequiredPacket(t *testing.T) {
+	pkt := NewRekeyRequiredPacket(0x12345678)
+
+	data := pkt.Marshal()
+
+	if len(data) != RekeyRequiredSize {
+		t.Errorf("expected size %d, got %d", RekeyRequiredSize, len(data))
+	}
+
+	if data[0] != PacketTypeRekeyRequired {
+		t.Errorf("expected type %d, got %d", PacketTypeRekeyRequired, data[0])
+	}
+
+	// Parse it back
+	parsed, err := UnmarshalRekeyRequired(data)
+	if err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if parsed.UnknownIndex != 0x12345678 {
+		t.Errorf("expected index 0x12345678, got 0x%x", parsed.UnknownIndex)
+	}
+}
+
+func TestRekeyRequiredPacketTooShort(t *testing.T) {
+	data := []byte{PacketTypeRekeyRequired, 0x01, 0x02} // Only 3 bytes, need 5
+
+	_, err := UnmarshalRekeyRequired(data)
+	if err == nil {
+		t.Error("expected error for short packet")
+	}
+}
+
+// =============================================================================
 // Replay Window Edge Case Tests
 // =============================================================================
 


### PR DESCRIPTION
## Summary
- Add `PacketTypeRekeyRequired` message type to handle stale session recovery
- When receiving data for unknown session, send rekey-required to peer
- Peer receives rekey-required, removes stale session, notifies upper layer
- Rate-limited to 5 second interval per source to prevent flooding

## Problem
When one peer restarts or loses session state, the other peer continues sending encrypted data packets to an unknown session index. These packets are silently dropped, and the sender has no way to know the session is stale - it just appears as packet loss.

## Solution
When a peer receives data packets for an unknown session, it now sends a `rekey-required` message back containing the unknown receiver_index. The sender, upon receiving this:
1. Finds the session with that local index
2. Removes the stale session from its maps
3. Calls the `onSessionInvalid` callback to notify upper layers

This allows the upper layer to trigger a new handshake/connection attempt.

## Test plan
- [x] Unit tests for packet marshal/unmarshal
- [x] All existing UDP tests pass
- [ ] Manual test with two peers where one restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)