### PR TITLE
Reconnect persistent relay on IP address change

### DIFF
--- a/internal/peer/heartbeat.go
+++ b/internal/peer/heartbeat.go
@@ -123,6 +123,11 @@ func (m *MeshNode) HandleIPChange(publicIPs, privateIPs []string, behindNAT bool
 	// Update stored IPs
 	m.SetHeartbeatIPs(publicIPs, privateIPs, behindNAT)
 
+	// Reconnect persistent relay (non-blocking)
+	if m.PersistentRelay != nil {
+		go m.ReconnectPersistentRelay(context.Background())
+	}
+
 	// Trigger discovery
 	m.TriggerDiscovery()
 }

--- a/internal/peer/network.go
+++ b/internal/peer/network.go
@@ -57,6 +57,10 @@ func (m *MeshNode) HandleNetworkChange(event netmon.Event) {
 		m.tunnelMgr.CloseAll()
 		log.Debug().Msg("closed stale tunnels after network change")
 		m.RecordNetworkChange()
+		// Reconnect persistent relay even if re-register failed
+		if m.PersistentRelay != nil {
+			go m.ReconnectPersistentRelay(context.Background())
+		}
 		m.TriggerDiscovery()
 		return
 	}


### PR DESCRIPTION
## Summary
- Add relay reconnection to `HandleIPChange()` in heartbeat.go
- Add relay reconnection to error path in `HandleNetworkChange()`

## Problem
When IP addresses change (e.g., switching from WiFi to mobile), tunnels are closed but the persistent relay was not being reconnected. This left the node with no connectivity until discovery completed and direct connections were established.

The logs showed:
```
IP addresses changed, re-registering...
closed stale tunnels due to IP change
no tunnel or relay for peer roku
```

## Root Cause
Two code paths handle IP changes:
1. `HandleNetworkChange()` - called from network monitor, reconnected relay only on success
2. `HandleIPChange()` - called from heartbeat loop, never reconnected relay

## Solution
Added relay reconnection to both paths so connectivity is restored immediately via relay while direct connections are being re-established.

## Test plan
- [x] All peer package tests pass
- [x] Linter passes
- [ ] Manual test: verify relay reconnects after network change

🤖 Generated with [Claude Code](https://claude.com/claude-code)