### PR TITLE
Fix relay stale reference and add diagnostic logging

### DIFF
--- a/internal/peer/node.go
+++ b/internal/peer/node.go
@@ -311,6 +311,10 @@ func (m *MeshNode) ReconnectPersistentRelay(ctx context.Context) {
 	if m.PersistentRelay != nil {
 		m.PersistentRelay.Close()
 		m.PersistentRelay = nil
+		// Clear forwarder's relay reference to prevent using stale closed relay
+		if m.Forwarder != nil {
+			m.Forwarder.SetRelay(nil)
+		}
 	}
 
 	// Small delay to let network settle


### PR DESCRIPTION
## Summary
- Clear forwarder's relay reference when closing old relay during reconnect
  to prevent using stale closed relay while reconnection is in progress
- Add DEBUG logging when forwarder relay reference is updated/cleared
- Add DEBUG logging when packets are dropped due to no tunnel/relay,
  showing relay state for diagnosis
- Add WARN logging when relay send fails
- Add TRACE logging for received relay packets

## Problem
After a connection change, the relay would reconnect but packets weren't being
routed. This was due to a timing window where the forwarder still held a reference
to the old (closed) relay while the new one was being established.

## Solution
When closing the old relay during reconnection, also clear the forwarder's
relay reference. This ensures packets will be explicitly dropped with a clear
"no tunnel or relay" message rather than silently failing via a closed relay.

## Test plan
- [x] Build succeeds
- [x] All tests pass
- [ ] Test relay routing after IP change

🤖 Generated with [Claude Code](https://claude.com/claude-code)