### PR TITLE
Fix tunnel disconnect during transport upgrade race

### DIFF
--- a/internal/peer/connection/fsm.go
+++ b/internal/peer/connection/fsm.go
@@ -163,6 +163,9 @@ func (pc *PeerConnection) TransitionTo(target State, reason string, err error) e
 			pc.reconnectCount++
 		}
 		pc.connectedSince = now
+		// Clear cancel function - outbound dial has succeeded, don't allow cancellation
+		// This prevents incoming connections from cancelling the HandleTunnel context
+		pc.cancelFunc = nil
 	}
 
 	// Build transition event


### PR DESCRIPTION
## Summary
- Clear `cancelFunc` when transitioning to Connected state to prevent incoming
  connections from cancelling the `HandleTunnel` context of an established tunnel

## Problem
When an outbound connection (e.g., SSH) succeeds and an incoming connection
(e.g., UDP) arrives simultaneously, the incoming handler would call
`CancelOutbound()` which cancelled the context used by `HandleTunnel`, causing
the established tunnel to disconnect immediately.

Timeline of the bug:
1. SSH outbound dial succeeds → transitions to Connected
2. UDP incoming handshake completes almost simultaneously
3. UDP handler calls `CancelOutbound(peerName)`
4. This cancels the context passed to `HandleTunnel`
5. SSH tunnel's `HandleTunnel` exits due to cancelled context
6. SSH tunnel disconnects with "tunnel handler exited"

## Solution
Clear the `cancelFunc` when transitioning TO `StateConnected`, since at that
point the outbound dial has succeeded and the context should no longer be
cancellable. This is the correct semantic - the cancel function is meant for
cancelling PENDING connection attempts, not established connections.

## Test plan
- [x] Added `TestPeerConnection_CancelFuncClearedOnConnected` - verifies cancel func is cleared
- [x] Added `TestPeerConnection_CancelOutboundDuringConnecting` - verifies normal cancel behavior
- [x] All existing tests pass with `-race` flag
- [ ] Test real-world transport upgrade scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)