### PR TITLE
Fix FSM bypass during network changes and refactor handlers

### DIFF
--- a/cmd/tunnelmesh/main.go
+++ b/cmd/tunnelmesh/main.go
@@ -815,8 +815,8 @@ func runJoinWithConfig(ctx context.Context, cfg *config.PeerConfig) error {
 		}
 	}
 
-	// Close all tunnels
-	node.TunnelMgr().CloseAll()
+	// Close all connections via FSM (properly transitions states and triggers observers)
+	node.Connections.CloseAll()
 
 	// Don't deregister on shutdown - keep the peer record so we get the same
 	// mesh IP when we reconnect. Use 'tunnelmesh leave' for intentional removal.

--- a/internal/peer/heartbeat.go
+++ b/internal/peer/heartbeat.go
@@ -109,9 +109,12 @@ func (m *MeshNode) HandleIPChange(publicIPs, privateIPs []string, behindNAT bool
 	// Close stale HTTP connections
 	m.client.CloseIdleConnections()
 
-	// Close all existing tunnels
+	// Disconnect all peers (tunnels may be using stale IPs)
+	// Use DisconnectAll to properly transition FSM states and trigger observers
+	m.Connections.DisconnectAll("IP change")
+	// Also close any orphaned tunnels not tracked by FSM (belt and suspenders)
 	m.tunnelMgr.CloseAll()
-	log.Debug().Msg("closed stale tunnels due to IP change")
+	log.Debug().Msg("disconnected all peers due to IP change")
 
 	// Update stored IPs
 	m.SetHeartbeatIPs(publicIPs, privateIPs, behindNAT)

--- a/internal/peer/incoming.go
+++ b/internal/peer/incoming.go
@@ -1,0 +1,66 @@
+package peer
+
+import (
+	"context"
+
+	"github.com/rs/zerolog/log"
+	"github.com/tunnelmesh/tunnelmesh/internal/transport"
+	"github.com/tunnelmesh/tunnelmesh/internal/tunnel"
+)
+
+// handleIncomingConnection handles an individual incoming connection (SSH or UDP).
+// This is the common logic shared between handleSSHConnection and handleUDPConnection.
+func (m *MeshNode) handleIncomingConnection(ctx context.Context, conn transport.Connection, transportName string) {
+	peerName := conn.PeerName()
+	if peerName == "" {
+		log.Warn().Str("transport", transportName).Msg("connection without peer name, rejecting")
+		conn.Close()
+		return
+	}
+
+	log.Info().
+		Str("peer", peerName).
+		Str("transport", string(conn.Type())).
+		Msg("incoming " + transportName + " connection")
+
+	// Cancel any outbound connection attempt to this peer
+	m.Connections.CancelOutbound(peerName)
+
+	// If we already have a healthy tunnel to this peer, reject the incoming connection
+	// to avoid race conditions where both peers connect simultaneously
+	if existing, ok := m.tunnelMgr.Get(peerName); ok {
+		if hc, canCheck := existing.(tunnel.HealthChecker); canCheck && hc.IsHealthy() {
+			log.Debug().
+				Str("peer", peerName).
+				Msg("already have healthy tunnel, rejecting incoming connection")
+			conn.Close()
+			return
+		}
+	}
+
+	// Fetch peer info from coordination server to get mesh IP and add route
+	// This ensures routing works immediately, without waiting for next discovery cycle
+	meshIP := m.ensurePeerRoute(peerName)
+
+	// Wrap connection as a tunnel
+	tun := tunnel.NewTunnelFromTransport(conn)
+
+	// Transition to Connected state (this adds tunnel via LifecycleManager observer)
+	pc := m.Connections.GetOrCreate(peerName, meshIP)
+	if err := pc.Connected(tun, "incoming "+transportName+" connection"); err != nil {
+		log.Warn().Err(err).Str("peer", peerName).Msg("failed to transition to connected state")
+		tun.Close()
+		return
+	}
+
+	log.Info().Str("peer", peerName).Msg("tunnel established from incoming " + transportName + " connection")
+
+	// Handle incoming packets from this tunnel
+	if m.Forwarder != nil {
+		go func(name string, p *tunnel.Tunnel, peerConn interface{ Disconnect(string, error) error }) {
+			m.Forwarder.HandleTunnel(ctx, name, p)
+			// Disconnect when tunnel handler exits (removes tunnel via LifecycleManager observer)
+			_ = peerConn.Disconnect("tunnel handler exited", nil)
+		}(peerName, tun, pc)
+	}
+}

--- a/internal/peer/ssh.go
+++ b/internal/peer/ssh.go
@@ -7,7 +7,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/tunnelmesh/tunnelmesh/internal/config"
 	"github.com/tunnelmesh/tunnelmesh/internal/transport"
-	"github.com/tunnelmesh/tunnelmesh/internal/tunnel"
 )
 
 // HandleIncomingSSH accepts incoming SSH connections from the transport listener.
@@ -22,63 +21,7 @@ func (m *MeshNode) HandleIncomingSSH(ctx context.Context, listener transport.Lis
 			continue
 		}
 
-		go m.handleSSHConnection(ctx, conn)
-	}
-}
-
-// handleSSHConnection handles an individual incoming SSH connection.
-func (m *MeshNode) handleSSHConnection(ctx context.Context, conn transport.Connection) {
-	peerName := conn.PeerName()
-	if peerName == "" {
-		log.Warn().Msg("SSH connection without peer name, rejecting")
-		conn.Close()
-		return
-	}
-
-	log.Info().
-		Str("peer", peerName).
-		Str("transport", string(conn.Type())).
-		Msg("incoming SSH connection")
-
-	// Cancel any outbound connection attempt to this peer
-	m.Connections.CancelOutbound(peerName)
-
-	// If we already have a healthy tunnel to this peer, reject the incoming connection
-	// to avoid race conditions where both peers connect simultaneously
-	if existing, ok := m.tunnelMgr.Get(peerName); ok {
-		if hc, canCheck := existing.(tunnel.HealthChecker); canCheck && hc.IsHealthy() {
-			log.Debug().
-				Str("peer", peerName).
-				Msg("already have healthy tunnel, rejecting incoming connection")
-			conn.Close()
-			return
-		}
-	}
-
-	// Fetch peer info from coordination server to get mesh IP and add route
-	// This ensures routing works immediately, without waiting for next discovery cycle
-	meshIP := m.ensurePeerRoute(peerName)
-
-	// Wrap connection as a tunnel
-	tun := tunnel.NewTunnelFromTransport(conn)
-
-	// Transition to Connected state (this adds tunnel via LifecycleManager observer)
-	pc := m.Connections.GetOrCreate(peerName, meshIP)
-	if err := pc.Connected(tun, "incoming SSH connection"); err != nil {
-		log.Warn().Err(err).Str("peer", peerName).Msg("failed to transition to connected state")
-		tun.Close()
-		return
-	}
-
-	log.Info().Str("peer", peerName).Msg("tunnel established from incoming SSH connection")
-
-	// Handle incoming packets from this tunnel
-	if m.Forwarder != nil {
-		go func(name string, p *tunnel.Tunnel, peerConn interface{ Disconnect(string, error) error }) {
-			m.Forwarder.HandleTunnel(ctx, name, p)
-			// Disconnect when tunnel handler exits (removes tunnel via LifecycleManager observer)
-			_ = peerConn.Disconnect("tunnel handler exited", nil)
-		}(peerName, tun, pc)
+		go m.handleIncomingConnection(ctx, conn, "SSH")
 	}
 }
 

--- a/internal/peer/ssh_test.go
+++ b/internal/peer/ssh_test.go
@@ -117,7 +117,7 @@ func TestMeshNode_HandleIncomingSSH_ContextCancel(t *testing.T) {
 	}
 }
 
-func TestMeshNode_HandleSSHConnection_EmptyPeerName(t *testing.T) {
+func TestMeshNode_HandleIncomingConnection_EmptyPeerName(t *testing.T) {
 	identity := &PeerIdentity{
 		Name: "test-node",
 		Config: &config.PeerConfig{
@@ -132,14 +132,14 @@ func TestMeshNode_HandleSSHConnection_EmptyPeerName(t *testing.T) {
 	ctx := context.Background()
 
 	// Should close connection when peer name is empty
-	node.handleSSHConnection(ctx, conn)
+	node.handleIncomingConnection(ctx, conn, "SSH")
 
 	if !conn.closeCalled {
 		t.Error("expected connection to be closed when peer name is empty")
 	}
 }
 
-func TestMeshNode_HandleSSHConnection_ValidPeer(t *testing.T) {
+func TestMeshNode_HandleIncomingConnection_ValidPeer(t *testing.T) {
 	identity := &PeerIdentity{
 		Name: "test-node",
 		Config: &config.PeerConfig{
@@ -154,7 +154,7 @@ func TestMeshNode_HandleSSHConnection_ValidPeer(t *testing.T) {
 	ctx := context.Background()
 
 	// Should add tunnel to manager
-	node.handleSSHConnection(ctx, conn)
+	node.handleIncomingConnection(ctx, conn, "SSH")
 
 	// Verify tunnel was added
 	tunnels := node.tunnelMgr.List()


### PR DESCRIPTION
## Summary
- Fix critical bug where network changes bypassed FSM, leaving connection states inconsistent
- Add `DisconnectAll()` method to LifecycleManager for non-terminal disconnection
- Extract common `handleIncomingConnection()` helper, reducing ~100 lines of duplication
- Ensure proper FSM state transitions during network/IP changes and shutdown

## Problem
After the FSM was introduced, the network change handlers (`network.go`, `heartbeat.go`) still called `tunnelMgr.CloseAll()` directly, bypassing the FSM:
- Tunnels were closed on `TunnelAdapter`
- `PeerConnection` states remained at `StateConnected`
- Routes were NOT removed (observers not called)
- Discovery couldn't reconnect because `StartConnecting()` failed (state was still `StateConnected`)

## Solution
1. Added `DisconnectAll(reason)` method to `LifecycleManager` that:
   - Transitions all connections to `StateDisconnected` (non-terminal, reusable)
   - Triggers observers to properly remove routes and tunnels
   - Preserves connection history/stats for reconnection

2. Updated network change handlers to use `DisconnectAll()` + `tunnelMgr.CloseAll()` (belt and suspenders)

3. Updated shutdown to use `Connections.CloseAll()` for proper FSM cleanup

4. Refactored SSH/UDP handlers to share common `handleIncomingConnection()` logic

## Test plan
- [x] All existing tests pass
- [x] New `TestLifecycleManager_DisconnectAll` test added and passes
- [x] Network change properly disconnects all peers via FSM
- [x] Discovery can reconnect after network change
- [ ] Manual testing with real network changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)