### PR TITLE
Move route management from FSM lifecycle to discovery

### DIFF
--- a/internal/peer/incoming.go
+++ b/internal/peer/incoming.go
@@ -38,9 +38,9 @@ func (m *MeshNode) handleIncomingConnection(ctx context.Context, conn transport.
 		}
 	}
 
-	// Fetch peer info from coordination server to get mesh IP and add route
-	// This ensures routing works immediately, without waiting for next discovery cycle
-	meshIP := m.ensurePeerRoute(peerName)
+	// Get cached mesh IP for FSM tracking
+	// Routes are managed atomically by discovery via UpdateRoutes()
+	meshIP, _ := m.GetCachedPeerMeshIP(peerName)
 
 	// Wrap connection as a tunnel
 	tun := tunnel.NewTunnelFromTransport(conn)

--- a/internal/peer/ssh.go
+++ b/internal/peer/ssh.go
@@ -2,10 +2,8 @@ package peer
 
 import (
 	"context"
-	"time"
 
 	"github.com/rs/zerolog/log"
-	"github.com/tunnelmesh/tunnelmesh/internal/config"
 	"github.com/tunnelmesh/tunnelmesh/internal/transport"
 )
 
@@ -25,85 +23,3 @@ func (m *MeshNode) HandleIncomingSSH(ctx context.Context, listener transport.Lis
 	}
 }
 
-// ensurePeerRoute fetches peer info from coordination server and ensures the route exists.
-// Retries on failure with exponential backoff, then falls back to cached peer info.
-// Returns the mesh IP for the peer (empty string if not found).
-func (m *MeshNode) ensurePeerRoute(peerName string) string {
-	if m.client == nil {
-		// Try cache if no client available
-		if meshIP, ok := m.GetCachedPeerMeshIP(peerName); ok {
-			m.router.AddRoute(meshIP, peerName)
-			log.Debug().
-				Str("peer", peerName).
-				Str("mesh_ip", meshIP).
-				Msg("route added from cache (no client)")
-			return meshIP
-		}
-		return ""
-	}
-
-	// Retry with exponential backoff
-	const maxRetries = 5
-	backoff := 500 * time.Millisecond
-
-	var lastErr error
-	for attempt := 1; attempt <= maxRetries; attempt++ {
-		peers, err := m.client.ListPeers()
-		if err != nil {
-			lastErr = err
-			log.Debug().
-				Err(err).
-				Str("peer", peerName).
-				Int("attempt", attempt).
-				Msg("failed to fetch peer info, retrying")
-			if attempt < maxRetries {
-				time.Sleep(backoff)
-				backoff *= 2
-			}
-			continue
-		}
-
-		for _, peer := range peers {
-			if peer.Name == peerName {
-				// Add route for this peer's mesh IP
-				m.router.AddRoute(peer.MeshIP, peer.Name)
-				// Cache for future use
-				m.CachePeerMeshIP(peer.Name, peer.MeshIP)
-				log.Debug().
-					Str("peer", peer.Name).
-					Str("mesh_ip", peer.MeshIP).
-					Msg("route added for incoming connection")
-
-				// Also add authorized key if we have the SSH transport
-				if peer.PublicKey != "" && m.SSHTransport != nil {
-					pubKey, err := config.DecodePublicKey(peer.PublicKey)
-					if err != nil {
-						log.Warn().Err(err).Str("peer", peer.Name).Msg("failed to decode peer public key")
-					} else {
-						m.SSHTransport.AddAuthorizedKey(pubKey)
-					}
-				}
-				return peer.MeshIP
-			}
-		}
-		// Peer not in list - don't retry, it's not a transient error
-		break
-	}
-
-	// All retries failed or peer not found, try cache
-	if meshIP, ok := m.GetCachedPeerMeshIP(peerName); ok {
-		m.router.AddRoute(meshIP, peerName)
-		log.Debug().
-			Str("peer", peerName).
-			Str("mesh_ip", meshIP).
-			Msg("route added from cache (retries exhausted)")
-		return meshIP
-	}
-
-	if lastErr != nil {
-		log.Warn().Err(lastErr).Str("peer", peerName).Msg("failed to fetch peer info for routing after retries")
-	} else {
-		log.Warn().Str("peer", peerName).Msg("peer not found on coordination server or in cache")
-	}
-	return ""
-}


### PR DESCRIPTION
## Summary
- Move route management from FSM lifecycle to discovery
- Use `UpdateRoutes()` for atomic route replacement (adds new peers, removes stale ones)
- Add `onDisconnect` callback to trigger discovery when peers disconnect
- Remove `ensurePeerRoute()` - routes are now added by discovery

## Problem
After restarting the service or disconnecting/reconnecting, packets took 60 seconds before routing successfully. This was because:
1. Routes were tied to tunnel lifecycle in the FSM
2. When a connection disconnected, the route was removed
3. Routes were only re-added on the next discovery cycle (60 seconds in normal phase)

## Solution
Routes are now managed exclusively by discovery using `UpdateRoutes()`:
- Discovery atomically replaces all routes with the current peer set from the coordination server
- Stale routes for removed peers are automatically cleaned up
- On disconnect, discovery is triggered immediately (via `onDisconnect` callback)
- Routes persist independently of tunnel state

## Test plan
- [x] All tests pass
- [x] Linter passes
- [ ] Manual test: verify packets route immediately after service restart
- [ ] Manual test: verify routes are cleaned up when peers leave the mesh

🤖 Generated with [Claude Code](https://claude.com/claude-code)