### PR TITLE
Trigger discovery on connect and debounce dead tunnel callbacks

### DIFF
--- a/internal/peer/node.go
+++ b/internal/peer/node.go
@@ -86,6 +86,12 @@ func NewMeshNode(identity *PeerIdentity, client *coord.Client) *MeshNode {
 	// with the coordination server's peer list
 	node.Connections = connection.NewLifecycleManager(connection.LifecycleConfig{
 		Tunnels: tunnelMgr,
+		OnConnect: func(peerName string) {
+			// Trigger discovery to refresh routes immediately on connect
+			// This ensures routes are current even if discovery hasn't run recently
+			log.Debug().Str("peer", peerName).Msg("peer connected, triggering discovery for route refresh")
+			node.TriggerDiscovery()
+		},
 		OnDisconnect: func(peerName string) {
 			// Trigger discovery to refresh routes and attempt reconnection
 			log.Debug().Str("peer", peerName).Msg("peer disconnected, triggering discovery")


### PR DESCRIPTION
## Summary
- Add `onConnect` callback to LifecycleManager, triggered when peer reaches StateConnected
- Wire `onConnect` to `TriggerDiscovery()` for immediate route refresh on new connections
- Add debounce (5s window) for dead tunnel callbacks to prevent callback storms
- Add tests for both new behaviors

## Problem
After network changes or mode switches, routing could be stale for up to 60 seconds (discovery interval) because:
1. Routes added by incoming connections could be overwritten by discovery's atomic `UpdateRoutes()` 
2. No immediate route refresh occurred when connections were established
3. Multiple rapid packet failures on dead tunnels triggered multiple disconnect callbacks

## Solution
Trigger discovery immediately when connections change (both connect and disconnect), ensuring routes stay synchronized with actual tunnel state. Also debounce dead tunnel callbacks to prevent noise from rapid failures.

## Test plan
- [x] All existing tests pass
- [x] New test for `OnConnect` callback (`TestLifecycleManager_OnConnectCallback`)
- [x] New test for dead tunnel debounce (`TestForwarder_DeadTunnelCallbackDebounced`)
- [ ] Manual testing: network switch, mode change scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)