### PR TITLE
Skip asymmetric tunnel detection for relay tunnels

### DIFF
--- a/internal/peer/connection/fsm_test.go
+++ b/internal/peer/connection/fsm_test.go
@@ -170,7 +170,7 @@ func TestPeerConnection_SetTunnel(t *testing.T) {
 	})
 
 	tunnel := &mockTunnel{}
-	pc.SetTunnel(tunnel)
+	pc.SetTunnel(tunnel, "test")
 
 	if pc.Tunnel() != tunnel {
 		t.Error("Tunnel() should return the set tunnel")
@@ -189,7 +189,7 @@ func TestPeerConnection_Connected(t *testing.T) {
 	})
 
 	tunnel := &mockTunnel{}
-	if err := pc.Connected(tunnel, "incoming connection"); err != nil {
+	if err := pc.Connected(tunnel, "test", "incoming connection"); err != nil {
 		t.Fatalf("Connected() failed: %v", err)
 	}
 
@@ -211,7 +211,7 @@ func TestPeerConnection_StartReconnecting(t *testing.T) {
 	})
 
 	tunnel := &mockTunnel{}
-	_ = pc.Connected(tunnel, "connected")
+	_ = pc.Connected(tunnel, "test", "connected")
 
 	err := errors.New("connection lost")
 	if err := pc.StartReconnecting("network error", err); err != nil {
@@ -234,7 +234,7 @@ func TestPeerConnection_ReconnectCount(t *testing.T) {
 
 	// Initial connect
 	tunnel1 := &mockTunnel{}
-	_ = pc.Connected(tunnel1, "connected")
+	_ = pc.Connected(tunnel1, "test", "connected")
 	if pc.ReconnectCount() != 0 {
 		t.Errorf("ReconnectCount() = %d, want 0 after initial connect", pc.ReconnectCount())
 	}
@@ -242,7 +242,7 @@ func TestPeerConnection_ReconnectCount(t *testing.T) {
 	// Reconnect
 	_ = pc.StartReconnecting("network error", nil)
 	tunnel2 := &mockTunnel{}
-	_ = pc.Connected(tunnel2, "reconnected")
+	_ = pc.Connected(tunnel2, "test", "reconnected")
 	if pc.ReconnectCount() != 1 {
 		t.Errorf("ReconnectCount() = %d, want 1 after first reconnect", pc.ReconnectCount())
 	}
@@ -250,7 +250,7 @@ func TestPeerConnection_ReconnectCount(t *testing.T) {
 	// Another reconnect
 	_ = pc.StartReconnecting("another error", nil)
 	tunnel3 := &mockTunnel{}
-	_ = pc.Connected(tunnel3, "reconnected again")
+	_ = pc.Connected(tunnel3, "test", "reconnected again")
 	if pc.ReconnectCount() != 2 {
 		t.Errorf("ReconnectCount() = %d, want 2 after second reconnect", pc.ReconnectCount())
 	}
@@ -263,7 +263,7 @@ func TestPeerConnection_Close(t *testing.T) {
 	})
 
 	tunnel := &mockTunnel{}
-	_ = pc.Connected(tunnel, "connected")
+	_ = pc.Connected(tunnel, "test", "connected")
 
 	if err := pc.Close(); err != nil {
 		t.Fatalf("Close() failed: %v", err)
@@ -292,7 +292,7 @@ func TestPeerConnection_CloseIdempotent(t *testing.T) {
 	})
 
 	tunnel := &mockTunnel{}
-	_ = pc.Connected(tunnel, "connected")
+	_ = pc.Connected(tunnel, "test", "connected")
 
 	// Close multiple times should not panic
 	pc.Close()
@@ -311,7 +311,7 @@ func TestPeerConnection_Disconnect(t *testing.T) {
 	})
 
 	tunnel := &mockTunnel{}
-	_ = pc.Connected(tunnel, "connected")
+	_ = pc.Connected(tunnel, "test", "connected")
 
 	if err := pc.Disconnect("user requested", nil); err != nil {
 		t.Fatalf("Disconnect() failed: %v", err)
@@ -326,7 +326,7 @@ func TestPeerConnection_Disconnect(t *testing.T) {
 
 	// Can reconnect after Disconnect (unlike Close)
 	tunnel2 := &mockTunnel{}
-	if err := pc.Connected(tunnel2, "reconnected"); err != nil {
+	if err := pc.Connected(tunnel2, "test", "reconnected"); err != nil {
 		t.Fatalf("Connected() after Disconnect() failed: %v", err)
 	}
 	if pc.State() != StateConnected {
@@ -355,7 +355,7 @@ func TestPeerConnection_Info(t *testing.T) {
 	}
 
 	tunnel := &mockTunnel{}
-	_ = pc.Connected(tunnel, "connected")
+	_ = pc.Connected(tunnel, "test", "connected")
 
 	info = pc.Info()
 	if info.State != StateConnected {
@@ -508,7 +508,7 @@ func TestPeerConnection_CancelFuncClearedOnConnected(t *testing.T) {
 
 	// Connect with a tunnel
 	tunnel := &mockTunnel{}
-	_ = pc.Connected(tunnel, "test")
+	_ = pc.Connected(tunnel, "test", "test")
 
 	// The cancel function should have been cleared during transition to Connected
 	// Calling CancelOutbound should NOT cancel anything
@@ -560,7 +560,7 @@ func TestPeerConnection_TunnelDataFlow(t *testing.T) {
 	pipe := newPipeRWC()
 	defer pipe.Close()
 
-	pc.SetTunnel(pipe)
+	pc.SetTunnel(pipe, "test")
 
 	// Verify tunnel is accessible
 	gotTunnel := pc.Tunnel()

--- a/internal/peer/connection/lifecycle_test.go
+++ b/internal/peer/connection/lifecycle_test.go
@@ -143,7 +143,7 @@ func TestLifecycleManager_OnConnectCallback(t *testing.T) {
 
 	// Connect - callback should be called
 	tunnel := &mockTunnel{}
-	_ = pc.Connected(tunnel, "test")
+	_ = pc.Connected(tunnel, "test", "test")
 
 	mu.Lock()
 	if len(connectedPeers) != 1 || connectedPeers[0] != "peer1" {
@@ -153,7 +153,7 @@ func TestLifecycleManager_OnConnectCallback(t *testing.T) {
 
 	// Disconnect and reconnect - callback should be called again
 	_ = pc.Disconnect("test", nil)
-	_ = pc.Connected(&mockTunnel{}, "reconnect")
+	_ = pc.Connected(&mockTunnel{}, "test", "reconnect")
 
 	mu.Lock()
 	if len(connectedPeers) != 2 {
@@ -181,7 +181,7 @@ func TestLifecycleManager_OnDisconnectCallback(t *testing.T) {
 
 	// Connect
 	tunnel := &mockTunnel{}
-	_ = pc.Connected(tunnel, "test")
+	_ = pc.Connected(tunnel, "test", "test")
 
 	// No callback yet
 	mu.Lock()
@@ -215,7 +215,7 @@ func TestLifecycleManager_TunnelLifecycle(t *testing.T) {
 
 	// Connect - tunnel should be added
 	tunnel := &mockTunnel{}
-	_ = pc.Connected(tunnel, "test")
+	_ = pc.Connected(tunnel, "test", "test")
 
 	if !tunnels.Has("peer1") {
 		t.Error("Tunnel should be added after Connected()")
@@ -243,7 +243,7 @@ func TestLifecycleManager_ReconnectingRemovesTunnel(t *testing.T) {
 
 	// Connect
 	tunnel := &mockTunnel{}
-	_ = pc.Connected(tunnel, "test")
+	_ = pc.Connected(tunnel, "test", "test")
 
 	if !tunnels.Has("peer1") {
 		t.Error("Tunnel should exist after Connected()")
@@ -258,7 +258,7 @@ func TestLifecycleManager_ReconnectingRemovesTunnel(t *testing.T) {
 
 	// Reconnect - tunnel should be added back
 	tunnel2 := &mockTunnel{}
-	_ = pc.Connected(tunnel2, "reconnected")
+	_ = pc.Connected(tunnel2, "test", "reconnected")
 
 	if !tunnels.Has("peer1") {
 		t.Error("Tunnel should exist after reconnect")
@@ -275,7 +275,7 @@ func TestLifecycleManager_CloseRemovesTunnel(t *testing.T) {
 
 	// Connect
 	tunnel := &mockTunnel{}
-	_ = pc.Connected(tunnel, "test")
+	_ = pc.Connected(tunnel, "test", "test")
 
 	// Close - tunnel should be removed
 	pc.Close()
@@ -293,7 +293,7 @@ func TestLifecycleManager_Remove(t *testing.T) {
 
 	pc := lm.GetOrCreate("peer1", "10.0.0.1")
 	tunnel := &mockTunnel{}
-	_ = pc.Connected(tunnel, "test")
+	_ = pc.Connected(tunnel, "test", "test")
 
 	// Remove from manager
 	lm.Remove("peer1")
@@ -321,8 +321,8 @@ func TestLifecycleManager_CloseAll(t *testing.T) {
 
 	tunnel1 := &mockTunnel{}
 	tunnel2 := &mockTunnel{}
-	_ = pc1.Connected(tunnel1, "test")
-	_ = pc2.Connected(tunnel2, "test")
+	_ = pc1.Connected(tunnel1, "test", "test")
+	_ = pc2.Connected(tunnel2, "test", "test")
 
 	// Close all
 	lm.CloseAll()
@@ -350,8 +350,8 @@ func TestLifecycleManager_DisconnectAll(t *testing.T) {
 
 	tunnel1 := &mockTunnel{}
 	tunnel2 := &mockTunnel{}
-	_ = pc1.Connected(tunnel1, "test")
-	_ = pc2.Connected(tunnel2, "test")
+	_ = pc1.Connected(tunnel1, "test", "test")
+	_ = pc2.Connected(tunnel2, "test", "test")
 
 	// Verify connections are in Connected state
 	if pc1.State() != StateConnected || pc2.State() != StateConnected {
@@ -386,7 +386,7 @@ func TestLifecycleManager_DisconnectAll(t *testing.T) {
 
 	// Connections can be reused - try reconnecting
 	newTunnel := &mockTunnel{}
-	err := pc1.Connected(newTunnel, "reconnection")
+	err := pc1.Connected(newTunnel, "test", "reconnection")
 	if err != nil {
 		t.Errorf("Should be able to reconnect after DisconnectAll: %v", err)
 	}
@@ -407,7 +407,7 @@ func TestLifecycleManager_ListByState(t *testing.T) {
 	_ = lm.GetOrCreate("peer3", "10.0.0.3") // stays disconnected
 
 	_ = pc1.StartConnecting("test")
-	_ = pc2.Connected(&mockTunnel{}, "test")
+	_ = pc2.Connected(&mockTunnel{}, "test", "test")
 
 	connecting := lm.ListByState(StateConnecting)
 	if len(connecting) != 1 || connecting[0] != "peer1" {
@@ -436,8 +436,8 @@ func TestLifecycleManager_CountByState(t *testing.T) {
 	pc2 := lm.GetOrCreate("peer2", "10.0.0.2")
 	_ = lm.GetOrCreate("peer3", "10.0.0.3") // stays disconnected
 
-	_ = pc1.Connected(&mockTunnel{}, "test")
-	_ = pc2.Connected(&mockTunnel{}, "test")
+	_ = pc1.Connected(&mockTunnel{}, "test", "test")
+	_ = pc2.Connected(&mockTunnel{}, "test", "test")
 
 	if lm.CountByState(StateConnected) != 2 {
 		t.Errorf("CountByState(Connected) = %d, want 2", lm.CountByState(StateConnected))
@@ -472,7 +472,7 @@ func TestLifecycleManager_IsConnecting(t *testing.T) {
 	}
 
 	// Connected
-	_ = pc.Connected(&mockTunnel{}, "test")
+	_ = pc.Connected(&mockTunnel{}, "test", "test")
 	if lm.IsConnecting("peer1") {
 		t.Error("IsConnecting() should return false for connected peer")
 	}
@@ -494,7 +494,7 @@ func TestLifecycleManager_IsConnected(t *testing.T) {
 	}
 
 	// Connected
-	_ = pc.Connected(&mockTunnel{}, "test")
+	_ = pc.Connected(&mockTunnel{}, "test", "test")
 	if !lm.IsConnected("peer1") {
 		t.Error("IsConnected() should return true for connected peer")
 	}
@@ -509,7 +509,7 @@ func TestLifecycleManager_State(t *testing.T) {
 	}
 
 	pc := lm.GetOrCreate("peer1", "10.0.0.1")
-	_ = pc.Connected(&mockTunnel{}, "test")
+	_ = pc.Connected(&mockTunnel{}, "test", "test")
 
 	if lm.State("peer1") != StateConnected {
 		t.Errorf("State() = %v, want Connected", lm.State("peer1"))
@@ -522,7 +522,7 @@ func TestLifecycleManager_AllInfo(t *testing.T) {
 	pc1 := lm.GetOrCreate("peer1", "10.0.0.1")
 	_ = lm.GetOrCreate("peer2", "10.0.0.2") // stays disconnected
 
-	_ = pc1.Connected(&mockTunnel{}, "test")
+	_ = pc1.Connected(&mockTunnel{}, "test", "test")
 
 	infos := lm.AllInfo()
 	if len(infos) != 2 {
@@ -553,7 +553,7 @@ func TestLifecycleManager_AddObserver(t *testing.T) {
 
 	// New connections should have the observer
 	pc := lm.GetOrCreate("peer1", "10.0.0.1")
-	_ = pc.Connected(&mockTunnel{}, "test")
+	_ = pc.Connected(&mockTunnel{}, "test", "test")
 
 	transitions := recorder.Transitions()
 	if len(transitions) != 1 {
@@ -580,7 +580,7 @@ func TestLifecycleManager_ConcurrentAccess(t *testing.T) {
 
 			pc := lm.GetOrCreate(peerName, meshIP)
 			_ = pc.StartConnecting("test")
-			_ = pc.Connected(&mockTunnel{}, "test")
+			_ = pc.Connected(&mockTunnel{}, "test", "test")
 			lm.List()
 			lm.Get(peerName)
 			lm.IsConnected(peerName)

--- a/internal/peer/discovery.go
+++ b/internal/peer/discovery.go
@@ -193,7 +193,7 @@ func (m *MeshNode) EstablishTunnel(ctx context.Context, peer proto.Peer) {
 		tun.Close()
 		return
 	}
-	if err := pc.Connected(tun, "transport negotiated: "+string(result.Transport)); err != nil {
+	if err := pc.Connected(tun, string(result.Transport), "transport negotiated: "+string(result.Transport)); err != nil {
 		log.Warn().Err(err).Str("peer", peer.Name).Msg("failed to transition to connected state")
 		tun.Close()
 		return

--- a/internal/peer/heartbeat.go
+++ b/internal/peer/heartbeat.go
@@ -203,7 +203,7 @@ func (m *MeshNode) connectRelay(ctx context.Context, peerName, jwtToken string) 
 
 	// Transition to Connected state (this adds tunnel via LifecycleManager observer)
 	pc := m.Connections.GetOrCreate(peerName, meshIP)
-	if err := pc.Connected(relayTunnel, "relay notification"); err != nil {
+	if err := pc.Connected(relayTunnel, "relay", "relay notification"); err != nil {
 		log.Warn().Err(err).Str("peer", peerName).Msg("failed to transition to connected state")
 		relayTunnel.Close()
 		return

--- a/internal/peer/incoming.go
+++ b/internal/peer/incoming.go
@@ -52,7 +52,7 @@ func (m *MeshNode) handleIncomingConnection(ctx context.Context, conn transport.
 
 	// Transition to Connected state (this adds tunnel via LifecycleManager observer)
 	pc := m.Connections.GetOrCreate(peerName, meshIP)
-	if err := pc.Connected(tun, "incoming "+transportName+" connection"); err != nil {
+	if err := pc.Connected(tun, transportName, "incoming "+transportName+" connection"); err != nil {
 		log.Warn().Err(err).Str("peer", peerName).Msg("failed to transition to connected state")
 		tun.Close()
 		return


### PR DESCRIPTION
## Summary
- Add transportType field to PeerConnection to track tunnel type ("udp", "ssh", "relay")
- Add TransportType() and IsRelayTunnel() methods to PeerConnection
- Skip asymmetric detection invalidation when the tunnel itself is a relay tunnel

## Problem
When both peers fell back to relay tunnels (because direct UDP/SSH connections failed), the asymmetric tunnel detection was incorrectly invalidating the relay tunnels. The detection logic saw "we have a tunnel but still receiving relay packets" and assumed the tunnel was stale. But if the tunnel IS a relay tunnel, receiving relay packets is expected behavior.

This caused a connection loop:
1. Direct connection fails, both peers establish relay tunnels
2. Relay packets arrive (as expected for relay tunnels)
3. Asymmetric detection invalidates the "stale" tunnel
4. Peers reconnect via relay
5. Repeat from step 2

## Solution
Track the transport type of each tunnel. When receiving relay packets or peer reconnect notifications, check if our tunnel is a relay tunnel. If so, skip the invalidation logic since relay packets are expected.

## Test plan
- [x] All tests pass
- [ ] Test relay-only connectivity between two peers

🤖 Generated with [Claude Code](https://claude.com/claude-code)