### PR TITLE
Don't invalidate direct tunnels on peer relay reconnect

### DIFF
--- a/internal/coord/relay.go
+++ b/internal/coord/relay.go
@@ -41,7 +41,7 @@ const (
 	MsgTypeRecvPacket      byte = 0x02 // Server -> Client: received packet from source peer
 	MsgTypePing            byte = 0x03 // Keepalive ping
 	MsgTypePong            byte = 0x04 // Keepalive pong
-	MsgTypePeerReconnected byte = 0x05 // Server -> Client: peer reconnected (invalidate tunnel)
+	MsgTypePeerReconnected byte = 0x05 // Server -> Client: peer reconnected (tunnel may be stale)
 )
 
 var upgrader = websocket.Upgrader{
@@ -94,7 +94,7 @@ func (r *relayManager) GetPersistent(peerName string) (*persistentConn, bool) {
 }
 
 // BroadcastPeerReconnected notifies all other connected peers that a peer has reconnected.
-// This allows them to invalidate stale tunnels to that peer.
+// Clients may use this to re-evaluate their connection state to that peer.
 func (r *relayManager) BroadcastPeerReconnected(reconnectedPeer string) {
 	r.mu.Lock()
 	peers := make([]*persistentConn, 0, len(r.persistent))


### PR DESCRIPTION
## Summary
- Stop invalidating UDP/SSH tunnels when peer reconnects to relay
- Only rely on relay packet reception to detect asymmetric situations

## Problem
The "peer reconnected to relay" notification was killing working UDP/SSH tunnels.
From the logs:
```
16:00:19Z INF incoming UDP connection peer=roku transport=udp
16:00:19Z DBG packet forwarded to tunnel  // Working fine!
...
16:02:11Z INF peer reconnected to relay, invalidating stale tunnel peer=roku
16:02:11Z INF tunnel closed peer=roku  // UDP tunnel killed!
```

The peer maintains a persistent relay connection for fallback. If that connection
hiccups and reconnects, it doesn't mean our direct tunnel is broken.

## Solution
- Remove tunnel invalidation from the "peer reconnected" handler entirely
- Keep the "relay packet received" handler for asymmetric detection
- If we have a direct tunnel but receive relay packets from the peer
  (meaning they can't reach us directly), that's when we invalidate

## Test plan
- [x] All tests pass
- [ ] Test UDP tunnel stability when peer relay reconnects

🤖 Generated with [Claude Code](https://claude.com/claude-code)