### PR TITLE
Replace HTTP heartbeat with WebSocket-based heartbeat

### DIFF
--- a/internal/coord/client.go
+++ b/internal/coord/client.go
@@ -93,45 +93,7 @@ func (c *Client) ListPeers() ([]proto.Peer, error) {
 	return result.Peers, nil
 }
 
-// Heartbeat sends a heartbeat to maintain presence.
-func (c *Client) Heartbeat(name, publicKey string) (*proto.HeartbeatResponse, error) {
-	return c.HeartbeatWithStats(name, publicKey, nil)
-}
-
-// HeartbeatWithStats sends a heartbeat with optional stats to maintain presence.
-// Returns the HeartbeatResponse which may include relay requests from other peers.
-func (c *Client) HeartbeatWithStats(name, publicKey string, stats *proto.PeerStats) (*proto.HeartbeatResponse, error) {
-	req := proto.HeartbeatRequest{
-		Name:      name,
-		PublicKey: publicKey,
-		Stats:     stats,
-	}
-
-	body, err := json.Marshal(req)
-	if err != nil {
-		return nil, fmt.Errorf("marshal request: %w", err)
-	}
-
-	resp, err := c.doRequest(http.MethodPost, "/api/v1/heartbeat", body)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, ErrPeerNotFound
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, c.parseError(resp)
-	}
-
-	var result proto.HeartbeatResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("decode response: %w", err)
-	}
-
-	return &result, nil
-}
+// Note: Heartbeat() and HeartbeatWithStats() removed - heartbeats now sent via WebSocket
 
 // Deregister removes this peer from the mesh.
 func (c *Client) Deregister(name string) error {

--- a/internal/coord/client_test.go
+++ b/internal/coord/client_test.go
@@ -62,49 +62,9 @@ func TestClient_ListPeers(t *testing.T) {
 	assert.Equal(t, "node1", peers[0].Name)
 }
 
-func TestClient_Heartbeat(t *testing.T) {
-	cfg := &config.ServerConfig{
-		Listen:       ":0",
-		AuthToken:    "test-token",
-		MeshCIDR:     "10.99.0.0/16",
-		DomainSuffix: ".tunnelmesh",
-	}
-	srv, err := NewServer(cfg)
-	require.NoError(t, err)
-
-	ts := httptest.NewServer(srv)
-	defer ts.Close()
-
-	client := NewClient(ts.URL, "test-token")
-
-	// Register first
-	_, err = client.Register("mynode", "SHA256:key", nil, nil, 2222, 0, false, "v1.0.0")
-	require.NoError(t, err)
-
-	// Heartbeat
-	_, err = client.Heartbeat("mynode", "SHA256:key")
-	assert.NoError(t, err)
-}
-
-func TestClient_HeartbeatNotFound(t *testing.T) {
-	cfg := &config.ServerConfig{
-		Listen:       ":0",
-		AuthToken:    "test-token",
-		MeshCIDR:     "10.99.0.0/16",
-		DomainSuffix: ".tunnelmesh",
-	}
-	srv, err := NewServer(cfg)
-	require.NoError(t, err)
-
-	ts := httptest.NewServer(srv)
-	defer ts.Close()
-
-	client := NewClient(ts.URL, "test-token")
-
-	// Heartbeat without registering should return ErrPeerNotFound
-	_, err = client.Heartbeat("unknown-node", "SHA256:key")
-	assert.ErrorIs(t, err, ErrPeerNotFound)
-}
+// Note: TestClient_Heartbeat and TestClient_HeartbeatNotFound removed.
+// Heartbeats are now sent via WebSocket using PersistentRelay.SendHeartbeat().
+// See internal/tunnel/persistent_relay_test.go for WebSocket heartbeat tests.
 
 func TestClient_Deregister(t *testing.T) {
 	cfg := &config.ServerConfig{

--- a/internal/coord/holepunch.go
+++ b/internal/coord/holepunch.go
@@ -338,6 +338,11 @@ func (s *Server) handleHolePunch(w http.ResponseWriter, r *http.Request) {
 	// Record this request so the target peer can be notified to hole-punch back
 	if req.FromPeer != "" && req.ToPeer != "" {
 		s.holePunch.RecordHolePunchRequest(req.FromPeer, req.ToPeer)
+
+		// Push notification to target peer via WebSocket if connected
+		if s.relay != nil {
+			s.relay.NotifyHolePunch(req.ToPeer, []string{req.FromPeer})
+		}
 	}
 
 	// Get target peer's endpoint

--- a/internal/coord/relay_test.go
+++ b/internal/coord/relay_test.go
@@ -1,0 +1,306 @@
+package coord
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tunnelmesh/tunnelmesh/internal/config"
+	"github.com/tunnelmesh/tunnelmesh/pkg/proto"
+)
+
+// Helper to create a WebSocket connection to the relay endpoint
+func connectRelay(t *testing.T, serverURL, peerName, jwtToken string) *websocket.Conn {
+	// Convert http:// to ws://
+	wsURL := strings.Replace(serverURL, "http://", "ws://", 1) + "/api/v1/relay/persistent"
+
+	dialer := websocket.Dialer{
+		HandshakeTimeout: 5 * time.Second,
+	}
+
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer "+jwtToken)
+
+	conn, _, err := dialer.Dial(wsURL, headers)
+	require.NoError(t, err, "failed to connect to relay")
+
+	return conn
+}
+
+func TestRelayManager_HandleHeartbeat(t *testing.T) {
+	cfg := &config.ServerConfig{
+		Listen:       ":0",
+		AuthToken:    "test-token",
+		MeshCIDR:     "10.99.0.0/16",
+		DomainSuffix: ".tunnelmesh",
+		Relay:        config.RelayConfig{Enabled: true},
+	}
+	srv, err := NewServer(cfg)
+	require.NoError(t, err)
+
+	// Start test server
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// Register a peer first to get a JWT token
+	peerName := "test-peer"
+	jwtToken := registerPeerAndGetToken(t, ts.URL, peerName, cfg.AuthToken)
+
+	// Connect to persistent relay
+	conn := connectRelay(t, ts.URL, peerName, jwtToken)
+	defer conn.Close()
+
+	// Give server time to register the connection
+	time.Sleep(50 * time.Millisecond)
+
+	// Send heartbeat with stats
+	stats := &proto.PeerStats{
+		PacketsSent:     100,
+		PacketsReceived: 50,
+		BytesSent:       5000,
+		BytesReceived:   2500,
+		ActiveTunnels:   2,
+	}
+	statsJSON, _ := json.Marshal(stats)
+
+	// Build message: [MsgTypeHeartbeat][stats_len:2][stats JSON]
+	msg := make([]byte, 1+2+len(statsJSON))
+	msg[0] = MsgTypeHeartbeat
+	msg[1] = byte(len(statsJSON) >> 8)
+	msg[2] = byte(len(statsJSON))
+	copy(msg[3:], statsJSON)
+
+	err = conn.WriteMessage(websocket.BinaryMessage, msg)
+	require.NoError(t, err)
+
+	// Read heartbeat ack
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	_, ackData, err := conn.ReadMessage()
+	require.NoError(t, err)
+
+	assert.Equal(t, MsgTypeHeartbeatAck, ackData[0], "should receive heartbeat ack")
+
+	// Verify peer stats were updated
+	srv.peersMu.RLock()
+	peer, exists := srv.peers[peerName]
+	srv.peersMu.RUnlock()
+
+	require.True(t, exists, "peer should exist")
+	assert.WithinDuration(t, time.Now(), peer.peer.LastSeen, 2*time.Second, "LastSeen should be updated")
+	if peer.stats != nil {
+		assert.Equal(t, uint64(100), peer.stats.PacketsSent, "stats should be updated")
+	}
+}
+
+func TestRelayManager_NotifyRelayRequest(t *testing.T) {
+	cfg := &config.ServerConfig{
+		Listen:       ":0",
+		AuthToken:    "test-token",
+		MeshCIDR:     "10.99.0.0/16",
+		DomainSuffix: ".tunnelmesh",
+		Relay:        config.RelayConfig{Enabled: true},
+	}
+	srv, err := NewServer(cfg)
+	require.NoError(t, err)
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// Register peer
+	peerName := "test-peer"
+	jwtToken := registerPeerAndGetToken(t, ts.URL, peerName, cfg.AuthToken)
+
+	// Connect to persistent relay
+	conn := connectRelay(t, ts.URL, peerName, jwtToken)
+	defer conn.Close()
+
+	// Give server time to register the connection
+	time.Sleep(50 * time.Millisecond)
+
+	// Call NotifyRelayRequest on the server
+	waitingPeers := []string{"peer2", "peer3"}
+	srv.relay.NotifyRelayRequest(peerName, waitingPeers)
+
+	// Read notification
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	_, data, err := conn.ReadMessage()
+	require.NoError(t, err)
+
+	// Parse notification
+	assert.Equal(t, MsgTypeRelayNotify, data[0], "should receive relay notify")
+	count := int(data[1])
+	assert.Equal(t, 2, count, "should have 2 peers")
+
+	// Parse peer names
+	peers := parsePeerList(data[2:], count)
+	assert.Equal(t, []string{"peer2", "peer3"}, peers)
+}
+
+func TestRelayManager_NotifyHolePunch(t *testing.T) {
+	cfg := &config.ServerConfig{
+		Listen:       ":0",
+		AuthToken:    "test-token",
+		MeshCIDR:     "10.99.0.0/16",
+		DomainSuffix: ".tunnelmesh",
+		Relay:        config.RelayConfig{Enabled: true},
+	}
+	srv, err := NewServer(cfg)
+	require.NoError(t, err)
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// Register peer
+	peerName := "test-peer"
+	jwtToken := registerPeerAndGetToken(t, ts.URL, peerName, cfg.AuthToken)
+
+	// Connect to persistent relay
+	conn := connectRelay(t, ts.URL, peerName, jwtToken)
+	defer conn.Close()
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Call NotifyHolePunch
+	requestingPeers := []string{"peer4"}
+	srv.relay.NotifyHolePunch(peerName, requestingPeers)
+
+	// Read notification
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	_, data, err := conn.ReadMessage()
+	require.NoError(t, err)
+
+	assert.Equal(t, MsgTypeHolePunchNotify, data[0], "should receive hole-punch notify")
+	count := int(data[1])
+	assert.Equal(t, 1, count, "should have 1 peer")
+
+	peers := parsePeerList(data[2:], count)
+	assert.Equal(t, []string{"peer4"}, peers)
+}
+
+func TestRelayManager_NotifyPeerNotConnected(t *testing.T) {
+	cfg := &config.ServerConfig{
+		Listen:       ":0",
+		AuthToken:    "test-token",
+		MeshCIDR:     "10.99.0.0/16",
+		DomainSuffix: ".tunnelmesh",
+		Relay:        config.RelayConfig{Enabled: true},
+	}
+	srv, err := NewServer(cfg)
+	require.NoError(t, err)
+
+	// Notify a peer that's not connected - should not panic
+	srv.relay.NotifyRelayRequest("nonexistent-peer", []string{"peer2"})
+	srv.relay.NotifyHolePunch("nonexistent-peer", []string{"peer2"})
+	// Test passes if no panic
+}
+
+func TestRelayManager_HeartbeatUpdatesStats(t *testing.T) {
+	cfg := &config.ServerConfig{
+		Listen:       ":0",
+		AuthToken:    "test-token",
+		MeshCIDR:     "10.99.0.0/16",
+		DomainSuffix: ".tunnelmesh",
+		Relay:        config.RelayConfig{Enabled: true},
+	}
+	srv, err := NewServer(cfg)
+	require.NoError(t, err)
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	peerName := "test-peer"
+	jwtToken := registerPeerAndGetToken(t, ts.URL, peerName, cfg.AuthToken)
+
+	conn := connectRelay(t, ts.URL, peerName, jwtToken)
+	defer conn.Close()
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Send multiple heartbeats with different stats
+	for i := 1; i <= 3; i++ {
+		stats := &proto.PeerStats{
+			PacketsSent: uint64(i * 100),
+			BytesSent:   uint64(i * 1000),
+		}
+		statsJSON, _ := json.Marshal(stats)
+
+		msg := make([]byte, 1+2+len(statsJSON))
+		msg[0] = MsgTypeHeartbeat
+		msg[1] = byte(len(statsJSON) >> 8)
+		msg[2] = byte(len(statsJSON))
+		copy(msg[3:], statsJSON)
+
+		err = conn.WriteMessage(websocket.BinaryMessage, msg)
+		require.NoError(t, err)
+
+		// Read ack
+		require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+		_, _, err = conn.ReadMessage()
+		require.NoError(t, err)
+	}
+
+	// Verify final stats
+	srv.peersMu.RLock()
+	peer := srv.peers[peerName]
+	srv.peersMu.RUnlock()
+
+	if peer.stats != nil {
+		assert.Equal(t, uint64(300), peer.stats.PacketsSent, "stats should reflect latest heartbeat")
+	}
+}
+
+// --- Helper functions ---
+
+func registerPeerAndGetToken(t *testing.T, serverURL, peerName, authToken string) string {
+	regReq := proto.RegisterRequest{
+		Name:       peerName,
+		PublicKey:  "SHA256:abc123",
+		PublicIPs:  []string{"1.2.3.4"},
+		PrivateIPs: []string{"192.168.1.100"},
+		SSHPort:    2222,
+	}
+	body, _ := json.Marshal(regReq)
+
+	req, _ := http.NewRequest(http.MethodPost, serverURL+"/api/v1/register", strings.NewReader(string(body)))
+	req.Header.Set("Authorization", "Bearer "+authToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var regResp proto.RegisterResponse
+	err = json.NewDecoder(resp.Body).Decode(&regResp)
+	require.NoError(t, err)
+
+	return regResp.Token
+}
+
+func parsePeerList(data []byte, count int) []string {
+	peers := make([]string, 0, count)
+	offset := 0
+	for i := 0; i < count; i++ {
+		if offset >= len(data) {
+			break
+		}
+		nameLen := int(data[offset])
+		if offset+1+nameLen > len(data) {
+			break
+		}
+		peers = append(peers, string(data[offset+1:offset+1+nameLen]))
+		offset += 1 + nameLen
+	}
+	return peers
+}
+
+// Ensure sync.WaitGroup is used (for compiler)
+var _ = sync.WaitGroup{}

--- a/pkg/proto/messages.go
+++ b/pkg/proto/messages.go
@@ -46,6 +46,7 @@ type RegisterResponse struct {
 }
 
 // PeerStats contains traffic statistics reported by peers.
+// Stats are now sent via WebSocket heartbeat (see internal/tunnel/persistent_relay.go).
 type PeerStats struct {
 	PacketsSent     uint64 `json:"packets_sent"`
 	PacketsReceived uint64 `json:"packets_received"`
@@ -57,19 +58,12 @@ type PeerStats struct {
 	ActiveTunnels   int    `json:"active_tunnels"`
 }
 
-// HeartbeatRequest is sent periodically to maintain presence.
-type HeartbeatRequest struct {
-	Name      string     `json:"name"`
-	PublicKey string     `json:"public_key"`
-	Stats     *PeerStats `json:"stats,omitempty"`
-}
-
-// HeartbeatResponse is returned after successful heartbeat.
-type HeartbeatResponse struct {
-	OK                bool     `json:"ok"`
-	RelayRequests     []string `json:"relay_requests,omitempty"`      // Peers waiting on relay for us
-	HolePunchRequests []string `json:"hole_punch_requests,omitempty"` // Peers wanting to UDP hole-punch with us
-}
+// Note: HeartbeatRequest and HeartbeatResponse removed.
+// Heartbeats are now sent via WebSocket using binary message format.
+// See internal/tunnel/persistent_relay.go (MsgTypeHeartbeat) and
+// internal/coord/relay.go for implementation.
+// Relay and hole-punch notifications are pushed instantly via WebSocket
+// (MsgTypeRelayNotify, MsgTypeHolePunchNotify).
 
 // RelayStatusResponse contains pending relay requests for a peer.
 type RelayStatusResponse struct {


### PR DESCRIPTION
## Summary
- Add heartbeat/stats and push notifications to existing WebSocket relay connection
- Remove HTTP heartbeat endpoint and replace with WebSocket binary messages
- Enable instant push notifications for relay and hole-punch requests

## Changes
- Add new message types (0x20-0x23) for heartbeat protocol in persistent_relay.go and relay.go
- Add `SendHeartbeat()` method and notification callbacks on `PersistentRelay`
- Handle `MsgTypeHeartbeat` on server to update peer stats and LastSeen
- Add `NotifyRelayRequest()` and `NotifyHolePunch()` methods to push notifications
- Rewrite `heartbeat.go` to use WebSocket instead of HTTP polling
- Wire up push triggers in `holepunch.go` when hole-punch requests are recorded
- Remove HTTP heartbeat endpoint from `server.go`
- Remove `Heartbeat`/`HeartbeatWithStats` methods from `client.go`
- Remove `HeartbeatRequest`/`HeartbeatResponse` from `messages.go`
- Update tests to remove HTTP heartbeat tests, add WebSocket heartbeat tests

## Benefits
- Instant push notifications (vs 5-30s polling delay)
- Single connection for both relay and heartbeat
- Lower overhead (no HTTP request/response headers)
- Cleaner codebase (old HTTP heartbeat code completely removed)

## Test plan
- [x] All existing tests pass
- [x] New relay_test.go tests for WebSocket heartbeat handling
- [x] New persistent_relay_test.go tests for client-side heartbeat
- [x] Linting passes
- [ ] Manual test with two peers

🤖 Generated with [Claude Code](https://claude.com/claude-code)