### PR TITLE
Add static IPs for DigitalOcean instances and coordinator taint target

### DIFF
--- a/terraform/modules/tunnelmesh-node/main.tf
+++ b/terraform/modules/tunnelmesh-node/main.tf
@@ -83,6 +83,17 @@ resource "digitalocean_droplet" "node" {
   })
 }
 
+# Reserved IP for static addressing
+resource "digitalocean_reserved_ip" "node" {
+  region = var.region
+}
+
+# Assign the reserved IP to the droplet
+resource "digitalocean_reserved_ip_assignment" "node" {
+  ip_address = digitalocean_reserved_ip.node.ip_address
+  droplet_id = digitalocean_droplet.node.id
+}
+
 # Firewall
 resource "digitalocean_firewall" "node" {
   name        = "${var.name}-firewall"
@@ -164,11 +175,11 @@ resource "digitalocean_firewall" "node" {
   }
 }
 
-# DNS record
+# DNS record (points to reserved IP for stability)
 resource "digitalocean_record" "node" {
   domain = var.domain
   type   = "A"
   name   = var.name
-  value  = digitalocean_droplet.node.ipv4_address
+  value  = digitalocean_reserved_ip.node.ip_address
   ttl    = 300
 }

--- a/terraform/modules/tunnelmesh-node/outputs.tf
+++ b/terraform/modules/tunnelmesh-node/outputs.tf
@@ -6,7 +6,17 @@ output "droplet_id" {
 }
 
 output "ipv4_address" {
-  description = "The public IPv4 address of the droplet"
+  description = "The static reserved IPv4 address"
+  value       = digitalocean_reserved_ip.node.ip_address
+}
+
+output "reserved_ip" {
+  description = "The reserved IP address (static)"
+  value       = digitalocean_reserved_ip.node.ip_address
+}
+
+output "droplet_ipv4_address" {
+  description = "The dynamic IPv4 address of the droplet (use reserved_ip for stable addressing)"
   value       = digitalocean_droplet.node.ipv4_address
 }
 
@@ -22,7 +32,7 @@ output "hostname" {
 
 output "ssh_command" {
   description = "SSH command to connect to the droplet"
-  value       = "ssh root@${digitalocean_droplet.node.ipv4_address}"
+  value       = "ssh root@${digitalocean_reserved_ip.node.ip_address}"
 }
 
 # Coordinator-specific outputs
@@ -33,7 +43,7 @@ output "coordinator_url" {
 
 output "coordinator_api_url" {
   description = "API URL for peers to connect to"
-  value       = var.coordinator_enabled ? (var.ssl_enabled ? "https://${var.name}.${var.domain}" : "http://${digitalocean_droplet.node.ipv4_address}:${var.coordinator_port}") : null
+  value       = var.coordinator_enabled ? (var.ssl_enabled ? "https://${var.name}.${var.domain}" : "http://${digitalocean_reserved_ip.node.ip_address}:${var.coordinator_port}") : null
 }
 
 # WireGuard-specific outputs

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -31,6 +31,11 @@ output "ssh_commands" {
 # COORDINATOR
 # ============================================================================
 
+output "coordinator_name" {
+  description = "Name of the coordinator node"
+  value       = local.coordinator_name
+}
+
 output "coordinator_url" {
   description = "Coordination server URL"
   value       = local.coordinator_name != null ? module.node[local.coordinator_name].coordinator_url : var.external_coordinator_url


### PR DESCRIPTION
## Summary
- Add reserved IP resources for all terraformed DigitalOcean droplets to ensure static addressing
- Update DNS records to point to reserved IPs instead of dynamic droplet IPs
- Add `deploy-taint-coordinator` make target to easily recreate the coordinator droplet

## Test plan
- [x] Terraform validates successfully
- [x] All Go tests pass
- [ ] Deploy to DigitalOcean and verify reserved IPs are assigned
- [ ] Test `make deploy-taint-coordinator` recreates droplet while preserving IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)