### PR TITLE
Use short commit hash for VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ BINARY_NAME=tunnelmesh
 BUILD_DIR=bin
 GO=go
 
-# Version info (use short commit ID if no tag)
-VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+# Version info (use short commit ID)
+VERSION ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "dev")
 COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_TIME ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS=-ldflags "-s -w -X main.Version=$(VERSION) -X main.Commit=$(COMMIT) -X main.BuildTime=$(BUILD_TIME)"


### PR DESCRIPTION
## Summary
- Use `git rev-parse --short HEAD` instead of `git describe --tags --always` for VERSION

## Problem
`git describe` produces `77bf625-7-g4319d15` format when there are commits after a tag, but GitHub releases use just the commit hash (`4319d15`). This caused the update command to incorrectly detect updates were available even when running the latest version.

## Test plan
- [x] Build and verify version format is just the commit hash
- [x] `tunnelmesh update --check` correctly shows "Already up to date" when on latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)