### PR TITLE
Use built-in service install and update commands

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -98,6 +98,10 @@ module "node" {
   ssl_enabled = lookup(each.value, "coordinator", false)
   ssl_email   = var.ssl_email
 
+  # Auto-update settings
+  auto_update_enabled  = var.auto_update_enabled
+  auto_update_schedule = var.auto_update_schedule
+
   tags = concat(
     ["tunnelmesh"],
     lookup(each.value, "coordinator", false) ? ["coordinator"] : [],

--- a/terraform/modules/tunnelmesh-node/main.tf
+++ b/terraform/modules/tunnelmesh-node/main.tf
@@ -81,6 +81,10 @@ resource "digitalocean_droplet" "node" {
 
     # SSL settings
     ssl_email = local.ssl_email
+
+    # Auto-update settings
+    auto_update_enabled  = var.auto_update_enabled
+    auto_update_schedule = var.auto_update_schedule
   })
 }
 

--- a/terraform/modules/tunnelmesh-node/variables.tf
+++ b/terraform/modules/tunnelmesh-node/variables.tf
@@ -158,3 +158,17 @@ variable "ssl_email" {
   type        = string
   default     = ""
 }
+
+# --- Auto-Update Settings ---
+
+variable "auto_update_enabled" {
+  description = "Enable automatic updates via systemd timer"
+  type        = bool
+  default     = true
+}
+
+variable "auto_update_schedule" {
+  description = "Schedule for auto-updates (systemd OnCalendar format: hourly, daily, weekly)"
+  type        = string
+  default     = "hourly"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -135,3 +135,15 @@ variable "ssl_email" {
   type        = string
   default     = ""
 }
+
+variable "auto_update_enabled" {
+  description = "Enable automatic updates on all nodes"
+  type        = bool
+  default     = true
+}
+
+variable "auto_update_schedule" {
+  description = "Schedule for auto-updates (systemd OnCalendar format: hourly, daily, weekly)"
+  type        = string
+  default     = "hourly"
+}


### PR DESCRIPTION
## Summary
- Replace manual systemd service creation in cloud-init with `tunnelmesh service install` command
- Replace manual binary download/restart in Makefile with `tunnelmesh update` command
- Add Terraform-configurable auto-update timer (`auto_update_enabled`, `auto_update_schedule`)

## Problem
The cloud-init template manually created systemd unit files, which could cause inconsistency if a user later ran `tunnelmesh service install` on the same machine. The Makefile's `deploy-update` targets manually downloaded binaries and used `systemctl restart`, missing the built-in update command's checksum verification, backup, and rollback capabilities.

## Solution
- Cloud-init now uses `tunnelmesh service install --mode serve/join --config <path> --force` instead of manually creating service files
- Makefile `deploy-update` and `deploy-update-node` targets now use `tunnelmesh update [version]` instead of manual curl/systemctl
- Added optional auto-update systemd timer (hourly by default, configurable via Terraform)

## Test plan
- [x] All Go tests pass
- [x] Terraform validation passes
- [x] Go build succeeds
- [x] Linting passes
- [ ] Test deployment with new cloud-init on fresh node

🤖 Generated with [Claude Code](https://claude.com/claude-code)