### PR TITLE
Fix service start command to use correct mode

### DIFF
--- a/terraform/modules/tunnelmesh-node/templates/cloud-init.sh.tpl
+++ b/terraform/modules/tunnelmesh-node/templates/cloud-init.sh.tpl
@@ -224,7 +224,11 @@ sysctl -p
 %{ endif ~}
 
 # Start the tunnelmesh service
-/usr/local/bin/tunnelmesh service start
+%{ if coordinator_enabled ~}
+/usr/local/bin/tunnelmesh service start --mode serve
+%{ else ~}
+/usr/local/bin/tunnelmesh service start --mode join
+%{ endif ~}
 
 %{ if coordinator_enabled && ssl_enabled ~}
 # Wait for DNS propagation and obtain SSL certificate


### PR DESCRIPTION
## Summary
- Fix `service start` command in cloud-init to use `--mode serve` or `--mode join` to match the installed service name

## Problem
The service install command creates a service named based on the mode:
- `--mode serve` → service named `tunnelmesh-server`
- `--mode join` → service named `tunnelmesh`

The `service start` command was missing the `--mode` flag, so it defaulted to join mode and tried to start `tunnelmesh` even when the installed service was `tunnelmesh-server`, causing:
```
Error: start service: exit status 5
```

## Solution
Add conditional `--mode serve` or `--mode join` to the start command based on `coordinator_enabled`.

## Test plan
- [ ] Deploy fresh node with `make deploy` and verify service starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)