### PR TITLE
Fix cloud-init service start command syntax

### DIFF
--- a/terraform/modules/tunnelmesh-node/templates/cloud-init.sh.tpl
+++ b/terraform/modules/tunnelmesh-node/templates/cloud-init.sh.tpl
@@ -225,9 +225,9 @@ sysctl -p
 
 # Start the tunnelmesh service
 %{ if coordinator_enabled ~}
-/usr/local/bin/tunnelmesh service start --mode serve
+/usr/local/bin/tunnelmesh service start --name tunnelmesh-server
 %{ else ~}
-/usr/local/bin/tunnelmesh service start --mode join
+/usr/local/bin/tunnelmesh service start --name tunnelmesh
 %{ endif ~}
 
 %{ if coordinator_enabled && ssl_enabled ~}


### PR DESCRIPTION
## Summary
- Fix `service start` command in cloud-init template to use `--name` flag instead of invalid `--mode` flag
- `--mode` is only valid for `service install`, not `service start`

## Problem
Cloud-init was failing because the service start commands used invalid syntax:
```bash
/usr/local/bin/tunnelmesh service start --mode serve  # Invalid
/usr/local/bin/tunnelmesh service start --mode join   # Invalid
```

## Solution
Changed to use `--name` flag with correct service names:
```bash
/usr/local/bin/tunnelmesh service start --name tunnelmesh-server  # Coordinator
/usr/local/bin/tunnelmesh service start --name tunnelmesh         # Peer
```

## Test plan
- [ ] Deploy new node and verify service starts correctly
- [ ] Verify both coordinator and peer configurations work

🤖 Generated with [Claude Code](https://claude.com/claude-code)