### PR TITLE
Fix systemd service file missing After= directive

### DIFF
--- a/internal/svc/service.go
+++ b/internal/svc/service.go
@@ -140,7 +140,7 @@ func NewServiceConfig(cfg *ServiceConfig, execPath string) *service.Config {
 	// Platform-specific options
 	switch runtime.GOOS {
 	case "linux":
-		svcCfg.Dependencies = []string{"network-online.target"}
+		svcCfg.Dependencies = []string{"After=network-online.target", "Wants=network-online.target"}
 		svcCfg.Option = service.KeyValue{
 			"Restart":    "on-failure",
 			"RestartSec": "5",


### PR DESCRIPTION
## Summary
- Fix systemd service file generation to include proper `After=` and `Wants=` directives

## Problem
The kardianos/service library requires full directives in the `Dependencies` slice, not just target names. Our code was passing:
```go
Dependencies = []string{"network-online.target"}
```

This caused systemd to output a malformed unit file:
```
[Unit]
Description=TunnelMesh P2P mesh network peer daemon
ConditionFileIsExecutable=/usr/local/bin/tunnelmesh
 
network-online.target   <-- Missing "After=" prefix, systemd ignores this line
```

This resulted in:
- Peers not properly waiting for network before starting
- Peers failing to connect to the coordinator

## Solution
Changed to pass full directives:
```go
Dependencies = []string{"After=network-online.target", "Wants=network-online.target"}
```

## Test plan
- [x] Build succeeds
- [ ] Reinstall service on nodes and verify unit file is correct
- [ ] Verify peers connect after service restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)