### PR TITLE
Add retry with exponential backoff for peer registration

### DIFF
--- a/cmd/tunnelmesh/main.go
+++ b/cmd/tunnelmesh/main.go
@@ -544,7 +544,9 @@ func runJoinWithConfig(ctx context.Context, cfg *config.PeerConfig) error {
 
 	// UDP port is SSH port + 1
 	udpPort := cfg.SSHPort + 1
-	resp, err := client.Register(cfg.Name, pubKeyEncoded, publicIPs, privateIPs, cfg.SSHPort, udpPort, behindNAT, Version)
+
+	// Register with retry and exponential backoff
+	resp, err := client.RegisterWithRetry(ctx, cfg.Name, pubKeyEncoded, publicIPs, privateIPs, cfg.SSHPort, udpPort, behindNAT, Version, coord.DefaultRetryConfig())
 	if err != nil {
 		return fmt.Errorf("register with server: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Add `RegisterWithRetry` method to `coord.Client` with exponential backoff
- Peer now retries registration up to 10 times (configurable) if coordinator isn't ready

## Problem
When deploying infrastructure, peers would start before the coordinator was ready, causing:
```
FTL service error error="register with server: dial tcp 129.212.201.115:443: connect: connection refused"
```

The service would exit immediately with no retry, requiring manual intervention or relying on slow systemd restarts.

## Solution
Added `RegisterWithRetry` with:
- Configurable max retries (default: 10)
- Exponential backoff starting at 2s, capping at 60s
- Context cancellation support for graceful shutdown
- Comprehensive test coverage

## Test plan
- [x] All tests pass
- [x] Lint passes
- [x] New tests cover: success on first try, success after failures, max retries exceeded, context cancellation, connection refused

🤖 Generated with [Claude Code](https://claude.com/claude-code)