### PR TITLE
Fix same-network peer detection using stale cached IPs

### DIFF
--- a/internal/transport/udp/transport.go
+++ b/internal/transport/udp/transport.go
@@ -895,39 +895,36 @@ func (t *Transport) Dial(ctx context.Context, opts transport.DialOptions) (trans
 		}
 	}
 
+	// Get peer's current external endpoint from coordination server
+	// This is the authoritative source for where the peer currently is
+	peerEndpoint, err := t.getPeerEndpoint(ctx, opts.PeerName)
+	if err != nil {
+		return nil, fmt.Errorf("get peer endpoint: %w", err)
+	}
+
 	// Check if peer is on the same network (same public IP = same NAT)
 	// If so, use private IPs to avoid NAT hairpinning issues
-	// Use fresh IP detection to avoid stale cached addresses after network changes
-	var peerEndpoint string
+	// IMPORTANT: Use the fresh external address from coordination, not cached PeerInfo
 	if opts.PeerInfo != nil && len(opts.PeerInfo.PrivateIPs) > 0 && opts.PeerInfo.UDPPort > 0 {
-		// Get our current public IPs freshly to handle network changes
-		ourPublicIPs, _, _ := proto.GetLocalIPs()
-		for _, ourPublicIP := range ourPublicIPs {
-			for _, peerPublicIP := range opts.PeerInfo.PublicIPs {
-				if ourPublicIP == peerPublicIP {
+		// Extract peer's current public IP from external endpoint (host:port format)
+		peerExternalHost, _, _ := net.SplitHostPort(peerEndpoint)
+		if peerExternalHost != "" {
+			// Get our current public IPs freshly to handle network changes
+			ourPublicIPs, _, _ := proto.GetLocalIPs()
+			for _, ourPublicIP := range ourPublicIPs {
+				if ourPublicIP == peerExternalHost {
 					// Same public IP means same LAN - use private IP to avoid hairpinning
-					peerEndpoint = net.JoinHostPort(opts.PeerInfo.PrivateIPs[0], fmt.Sprint(opts.PeerInfo.UDPPort))
+					privateEndpoint := net.JoinHostPort(opts.PeerInfo.PrivateIPs[0], fmt.Sprint(opts.PeerInfo.UDPPort))
 					log.Debug().
 						Str("peer", opts.PeerName).
 						Str("our_public_ip", ourPublicIP).
-						Str("peer_public_ip", peerPublicIP).
-						Str("using_private_addr", peerEndpoint).
+						Str("peer_external_ip", peerExternalHost).
+						Str("using_private_addr", privateEndpoint).
 						Msg("detected same-network peer, using private IP to avoid NAT hairpinning")
+					peerEndpoint = privateEndpoint
 					break
 				}
 			}
-			if peerEndpoint != "" {
-				break
-			}
-		}
-	}
-
-	// If not same network, get peer's UDP endpoint via coordination server
-	if peerEndpoint == "" {
-		var err error
-		peerEndpoint, err = t.getPeerEndpoint(ctx, opts.PeerName)
-		if err != nil {
-			return nil, fmt.Errorf("get peer endpoint: %w", err)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Get peer's current external address from coordination server BEFORE same-network check
- Compare against fresh external IP instead of stale cached `PeerInfo.PublicIPs`
- Fixes incorrect same-network detection when peer changes networks

## Problem
When peer A was on the same network as peer B (home WiFi), then moved to mobile, peer B's same-network detection still used the cached old public IP. This caused B to:
1. Detect "same network" incorrectly (stale cached IP matched our public IP)
2. Try to connect via peer A's private IP (e.g., `192.168.1.86:2228`)
3. Fail because peer A is now on mobile and unreachable via that private IP

From logs:
```
hole-punch coordination successful, sending packets peer=roku peer_external=82.132.237.135
...
detected same-network peer, using private IP peer_public_ip=86.169.165.186 using_private_addr=192.168.1.86:2228
```
The coordination server returned the correct new address (`82.132.237.135`), but the code used the stale cached `86.169.165.186` for same-network detection.

## Solution
Reorder the logic:
1. **Before**: Check cached PublicIPs → getPeerEndpoint() only if not same-network
2. **After**: getPeerEndpoint() first → use fresh external IP for same-network check

This ensures same-network detection uses the peer's current location, not stale cached data.

## Test plan
- [x] All tests pass
- [ ] Test reconnection after peer switches from WiFi to mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)