### PR TITLE
Fix rekey-required packets being silently dropped

### DIFF
--- a/internal/transport/udp/transport.go
+++ b/internal/transport/udp/transport.go
@@ -434,7 +434,10 @@ func (t *Transport) receiveLoop(conn *net.UDPConn) {
 			continue
 		}
 
-		if n < MinPacketSize {
+		// Minimum 1 byte needed to check packet type
+		// Individual handlers validate their specific size requirements
+		// Note: RekeyRequired packets are only 5 bytes, smaller than data packets
+		if n < 1 {
 			continue // Too short
 		}
 


### PR DESCRIPTION
## Summary
- Fix UDP receive loop dropping packets smaller than 32 bytes
- Rekey-required packets (5 bytes) were being silently dropped before packet type check
- Add regression test to document size relationship

## Problem
When a peer restarts, it sends `rekey-required` messages to tell connected peers their session is stale and they need to re-handshake. However, these 5-byte packets were being silently dropped by the receive loop which checked `n < MinPacketSize` (32 bytes) **before** checking the packet type.

This caused tunnels to become one-way after a peer restart - the restarted peer would log "data packet for unknown session" and send rekey-required, but the other peer never received them and kept sending data to a dead session.

## Solution
Changed minimum packet size check from 32 bytes to 1 byte (minimum needed to check packet type). Individual handlers validate their specific size requirements:
- RekeyRequired: 5 bytes
- Handshake: validated by handshake unmarshaler
- Data/Keepalive: 32 bytes (header + auth tag)

## Test plan
- [x] All tests pass
- [x] Added regression test for packet size relationship
- [ ] Deploy and verify rekey-required messages are now received

🤖 Generated with [Claude Code](https://claude.com/claude-code)