### PR TITLE
Fix tile seams with GPU acceleration approach

### DIFF
--- a/internal/coord/web/css/style.css
+++ b/internal/coord/web/css/style.css
@@ -206,15 +206,27 @@ header h1 {
 /* Fix tile seams (white lines between tiles) */
 .leaflet-tile {
     outline: none !important;
-    filter: brightness(1.05) contrast(1.05);
+    /* GPU acceleration prevents subpixel gaps */
+    backface-visibility: hidden;
+    -webkit-backface-visibility: hidden;
+    transform: translate3d(0, 0, 0);
+    /* Slightly enlarge tiles to overlap seams */
+    margin: -0.5px;
 }
 
 .leaflet-tile-pane {
-    opacity: 1;
+    /* Force GPU layer for entire tile pane */
+    transform: translateZ(0);
+}
+
+.leaflet-tile-container {
+    backface-visibility: hidden;
+    -webkit-backface-visibility: hidden;
 }
 
 .leaflet-tile-container img {
-    outline: 1px solid transparent;
+    /* Prevent image edges from showing gaps */
+    display: block;
 }
 
 /* Leaflet control styling for dark theme */


### PR DESCRIPTION
## Summary
- Replace brightness/contrast filter approach with GPU acceleration

## Problem
The previous tile seam fix (PR #126) didn't work in the production environment but worked locally in Docker. This suggests browser-specific rendering differences.

## Solution
Use a more robust GPU acceleration approach that's commonly used for
fixing tile seams in Leaflet maps:

- `backface-visibility: hidden` - forces GPU layer
- `transform: translate3d(0,0,0)` - prevents subpixel rounding
- `margin: -0.5px` - slight overlap to cover any gaps
- `display: block` on img - prevents inline spacing issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)