### PR TITLE
Change this.tunnelmesh to resolve to coordinator's mesh IP

### DIFF
--- a/cmd/tunnelmesh/main.go
+++ b/cmd/tunnelmesh/main.go
@@ -324,6 +324,9 @@ func runServeFromService(ctx context.Context, configPath string) error {
 
 		// Callback to start admin HTTPS server after joining mesh
 		onJoined := func(meshIP string, tlsMgr *peer.TLSManager) {
+			// Set coordinator's mesh IP for "this.tunnelmesh" resolution
+			srv.SetCoordMeshIP(meshIP)
+
 			if cfg.Admin.Enabled && tlsMgr != nil {
 				// Load TLS cert for admin HTTPS
 				tlsCert, err := tlsMgr.LoadCert()
@@ -487,6 +490,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 		// Callback to start admin HTTPS server after joining mesh
 		onJoined := func(meshIP string, tlsMgr *peer.TLSManager) {
+			// Set coordinator's mesh IP for "this.tunnelmesh" resolution
+			srv.SetCoordMeshIP(meshIP)
+
 			if cfg.Admin.Enabled && tlsMgr != nil {
 				// Load TLS cert for admin HTTPS
 				tlsCert, err := tlsMgr.LoadCert()
@@ -1118,7 +1124,10 @@ func runJoinWithConfigAndCallback(ctx context.Context, cfg *config.PeerConfig, o
 	var dnsConfigured bool
 	if cfg.DNS.Enabled {
 		resolver := meshdns.NewResolver(resp.Domain, cfg.DNS.CacheTTL)
-		resolver.SetLocalMeshIP(resp.MeshIP) // Enable "this.tunnelmesh" resolution
+		// Set coordinator's mesh IP for "this.tunnelmesh" resolution
+		if resp.CoordMeshIP != "" {
+			resolver.SetCoordMeshIP(resp.CoordMeshIP)
+		}
 		node.Resolver = resolver
 
 		// Initial DNS sync

--- a/pkg/proto/messages.go
+++ b/pkg/proto/messages.go
@@ -81,12 +81,13 @@ type RegisterRequest struct {
 
 // RegisterResponse is returned after successful registration.
 type RegisterResponse struct {
-	MeshIP   string `json:"mesh_ip"`            // Assigned mesh IP address
-	MeshCIDR string `json:"mesh_cidr"`          // Full mesh CIDR for routing
-	Domain   string `json:"domain"`             // Domain suffix (e.g., ".tunnelmesh")
-	Token    string `json:"token"`              // JWT token for relay authentication
-	TLSCert  string `json:"tls_cert,omitempty"` // PEM-encoded TLS certificate signed by mesh CA
-	TLSKey   string `json:"tls_key,omitempty"`  // PEM-encoded TLS private key
+	MeshIP      string `json:"mesh_ip"`                 // Assigned mesh IP address
+	MeshCIDR    string `json:"mesh_cidr"`               // Full mesh CIDR for routing
+	Domain      string `json:"domain"`                  // Domain suffix (e.g., ".tunnelmesh")
+	Token       string `json:"token"`                   // JWT token for relay authentication
+	TLSCert     string `json:"tls_cert,omitempty"`      // PEM-encoded TLS certificate signed by mesh CA
+	TLSKey      string `json:"tls_key,omitempty"`       // PEM-encoded TLS private key
+	CoordMeshIP string `json:"coord_mesh_ip,omitempty"` // Coordinator's mesh IP for "this.tunnelmesh" resolution
 }
 
 // PeerStats contains traffic statistics reported by peers.


### PR DESCRIPTION
## Summary
- `this.tunnelmesh` now resolves to the **coordinator's** mesh IP instead of the local peer's IP
- Allows accessing the admin page from any peer via `https://this.tunnelmesh/`
- Requires coordinator to have `join_mesh` configured (which gives it a mesh IP)

## Changes
- Add `CoordMeshIP` field to `RegisterResponse` 
- Rename resolver's `localMeshIP` to `coordMeshIP`
- Add `SetCoordMeshIP()` method to Server struct
- Server sets coordMeshIP when joining mesh with join_mesh
- Peers use CoordMeshIP from registration response for "this" resolution

## Configuration
For terraform deployments, add `peer = true` to the coordinator node:

```hcl
nodes = {
  "tunnelmesh" = {
    coordinator = true
    peer        = true   # Required for this.tunnelmesh resolution
    ...
  }
}
```

## Test plan
- [ ] Build succeeds
- [ ] Tests pass
- [ ] Verify `this.tunnelmesh` resolves to coordinator's mesh IP
- [ ] Admin accessible at `https://this.tunnelmesh/` from peers

🤖 Generated with [Claude Code](https://claude.com/claude-code)