### PR TITLE
Add test coverage visibility with Codecov integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,27 @@ jobs:
         with:
           go-version: '1.24'
       - name: Run tests
+        if: matrix.os != 'ubuntu-latest'
         run: go test -race ./...
+      - name: Run tests with coverage
+        if: matrix.os == 'ubuntu-latest'
+        run: go test -race -coverprofile=coverage.out ./...
+      - name: Upload coverage to Codecov
+        if: matrix.os == 'ubuntu-latest'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.out
+          fail_ci_if_error: false
+      - name: Check coverage threshold
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | tr -d '%')
+          echo "Total coverage: $COVERAGE%"
+          if (( $(echo "$COVERAGE < 40" | bc -l) )); then
+            echo "::error::Coverage $COVERAGE% is below threshold of 40%"
+            exit 1
+          fi
 
   build:
     name: Build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # TunnelMesh
 
+[![CI](https://github.com/zombar/tunnelmesh/actions/workflows/ci.yml/badge.svg)](https://github.com/zombar/tunnelmesh/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/zombar/tunnelmesh/branch/main/graph/badge.svg)](https://codecov.io/gh/zombar/tunnelmesh)
+
 A peer-to-peer mesh networking tool that creates encrypted tunnels between nodes. TunnelMesh enables direct, secure communication between peers in a distributed topology without requiring a traditional VPN or centralized traffic routing.
 
 ## Features

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 40%
+        threshold: 2%
+    patch:
+      default:
+        target: 60%
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default


### PR DESCRIPTION
## Summary
- Add codecov.yml with 40% project target and 60% patch target
- Update CI workflow to generate coverage and upload to Codecov
- Add coverage threshold check (40% minimum) to CI
- Add CI and Codecov badges to README

## Current State
- 501 tests across 24 packages
- 44.4% overall coverage (above 40% threshold)
- Tests run on Linux, macOS, and Windows with race detector

## Setup Required After Merge
1. Visit https://app.codecov.io to configure Codecov for the repository
2. For private repos: add `CODECOV_TOKEN` as a GitHub repository secret

## Test plan
- [x] All tests pass locally
- [x] Coverage is 44.4%, above 40% threshold
- [ ] CI workflow runs successfully with coverage upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)