### PR TITLE
Add missing monitoring and auto-update variable documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,29 @@ Deploy the coordination server to DigitalOcean App Platform using Terraform.
 | `mesh_cidr` | Mesh network CIDR | `10.99.0.0/16` |
 | `region` | DO region | `ams` |
 | `locations_enabled` | Enable node location tracking | `false` |
+| `monitoring_enabled` | Enable monitoring stack (Prometheus, Grafana, Loki) | `false` |
+| `prometheus_retention_days` | Prometheus data retention in days | `3` |
+| `loki_retention_days` | Loki log retention in days | `3` |
+| `auto_update_enabled` | Enable automatic binary updates | `true` |
+| `auto_update_schedule` | Update schedule (hourly, daily, weekly) | `hourly` |
+
+### Monitoring Stack
+
+When `monitoring_enabled = true` is set in terraform.tfvars, the coordinator node is deployed with a full monitoring stack:
+
+- **Prometheus** - Metrics collection and alerting (scrapes peer metrics via mesh network)
+- **Grafana** - Dashboards and visualization (accessible at `/grafana/`)
+- **Loki** - Log aggregation (localhost:3100)
+- **SD Generator** - Automatic peer discovery for Prometheus targets
+
+All monitoring services listen on localhost only and are accessed through the nginx reverse proxy within the mesh network.
+
+The monitoring stack includes pre-configured alert rules for:
+- Peer disconnections and connectivity issues
+- Packet drops and error rates
+- WireGuard and relay status
+
+Access Grafana at `https://this.tunnelmesh/grafana/` from within the mesh network.
 
 ### Node Location Tracking
 

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -200,6 +200,30 @@ nodes = {
 # by their public IP addresses. This is disabled by default for privacy.
 # locations_enabled = false
 
+# ============================================================================
+# MONITORING SETTINGS
+# ============================================================================
+
+# Enable monitoring stack (Prometheus, Grafana, Loki) on coordinator node
+# Includes: Prometheus for metrics, Grafana for dashboards, Loki for logs
+# monitoring_enabled = false
+
+# Prometheus data retention in days (default: 3)
+# prometheus_retention_days = 3
+
+# Loki log retention in days (default: 3)
+# loki_retention_days = 3
+
+# ============================================================================
+# AUTO-UPDATE SETTINGS
+# ============================================================================
+
+# Enable automatic updates on all nodes
+# auto_update_enabled = true
+
+# Schedule for auto-updates (systemd OnCalendar format: hourly, daily, weekly)
+# auto_update_schedule = "hourly"
+
 # GitHub owner for binary downloads
 # github_owner = "zombar"
 


### PR DESCRIPTION
## Summary
- Add monitoring and auto-update variable documentation to `terraform.tfvars.example`
- Add monitoring stack section to README.md explaining the Prometheus, Grafana, Loki stack
- Add missing variables to Terraform Variables table in README.md

## Context
PR #138 introduced a fragment-based cloud-init architecture with monitoring support, but the documentation for the new variables was incomplete:
- `monitoring_enabled`
- `prometheus_retention_days`
- `loki_retention_days`
- `auto_update_enabled`
- `auto_update_schedule`

## Test plan
- [x] `terraform validate` passes
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)