### PR TITLE
Reduce server memory usage with quick wins

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,6 +19,9 @@ services:
         ipv4_address: 172.28.0.10
     ports:
       - "8880:8080"   # Admin UI + Prometheus/Grafana proxies
+      - "6060:6060"   # pprof (when PPROF_ADDR is set)
+    environment:
+      - PPROF_ADDR=localhost:6060  # Enable pprof for memory profiling
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/health"]
       interval: 5s

--- a/docker/scripts/server-entrypoint.sh
+++ b/docker/scripts/server-entrypoint.sh
@@ -10,6 +10,19 @@ if [ ! -f "$KEY_PATH" ]; then
     tunnelmesh init
 fi
 
+# Build command with optional flags
+CMD="tunnelmesh serve --config /etc/tunnelmesh/server.yaml"
+
+# Set log level from environment (default: info)
+LOG_LEVEL="${LOG_LEVEL:-info}"
+CMD="$CMD --log-level $LOG_LEVEL"
+
+# Enable pprof if PPROF_ADDR is set
+if [ -n "$PPROF_ADDR" ]; then
+    echo "Enabling pprof on $PPROF_ADDR"
+    CMD="$CMD --pprof-addr $PPROF_ADDR"
+fi
+
 # Start the server (which will also join the mesh as a client)
 echo "Starting mesh server..."
-exec tunnelmesh serve --config /etc/tunnelmesh/server.yaml --log-level info
+exec $CMD

--- a/internal/coord/geolocation.go
+++ b/internal/coord/geolocation.go
@@ -24,17 +24,22 @@ type ipAPIResponse struct {
 	Message    string  `json:"message,omitempty"`
 }
 
-// IPGeoCache caches IP geolocation results with rate limiting.
+// IPGeoCache caches IP geolocation results with rate limiting and LRU eviction.
 // It uses ip-api.com for lookups (free tier: 45 req/min).
 type IPGeoCache struct {
 	baseURL              string
 	cache                map[string]*proto.GeoLocation
+	accessOrder          []string // LRU order: oldest at front, newest at back
+	maxCacheSize         int
 	mu                   sync.RWMutex
 	client               *http.Client
 	maxRequestsPerMinute int
 	requestCount         int
 	windowStart          time.Time
 }
+
+// DefaultMaxCacheSize is the default maximum number of entries in the geolocation cache.
+const DefaultMaxCacheSize = 1000
 
 // NewIPGeoCache creates a new IP geolocation cache.
 // The baseURL should include the trailing slash, e.g., "http://ip-api.com/json/".
@@ -43,8 +48,10 @@ func NewIPGeoCache(baseURL string) *IPGeoCache {
 		baseURL = "http://ip-api.com/json/"
 	}
 	return &IPGeoCache{
-		baseURL: baseURL,
-		cache:   make(map[string]*proto.GeoLocation),
+		baseURL:      baseURL,
+		cache:        make(map[string]*proto.GeoLocation),
+		accessOrder:  make([]string, 0, DefaultMaxCacheSize),
+		maxCacheSize: DefaultMaxCacheSize,
 		client: &http.Client{
 			Timeout: 10 * time.Second,
 		},
@@ -62,12 +69,14 @@ func (c *IPGeoCache) Lookup(ctx context.Context, ip string) (*proto.GeoLocation,
 	}
 
 	// Check cache first
-	c.mu.RLock()
+	c.mu.Lock()
 	if loc, ok := c.cache[ip]; ok {
-		c.mu.RUnlock()
+		// Move to end of access order (most recently used)
+		c.moveToEnd(ip)
+		c.mu.Unlock()
 		return loc, nil
 	}
-	c.mu.RUnlock()
+	c.mu.Unlock()
 
 	// Rate limit check
 	c.mu.Lock()
@@ -123,9 +132,16 @@ func (c *IPGeoCache) Lookup(ctx context.Context, ip string) (*proto.GeoLocation,
 		UpdatedAt: time.Now(),
 	}
 
-	// Cache the result
+	// Cache the result with LRU eviction
 	c.mu.Lock()
+	// Evict oldest entries if at capacity
+	for len(c.cache) >= c.maxCacheSize && len(c.accessOrder) > 0 {
+		oldest := c.accessOrder[0]
+		c.accessOrder = c.accessOrder[1:]
+		delete(c.cache, oldest)
+	}
 	c.cache[ip] = loc
+	c.accessOrder = append(c.accessOrder, ip)
 	c.mu.Unlock()
 
 	log.Debug().
@@ -136,4 +152,23 @@ func (c *IPGeoCache) Lookup(ctx context.Context, ip string) (*proto.GeoLocation,
 		Msg("IP geolocation cached")
 
 	return loc, nil
+}
+
+// moveToEnd moves an IP to the end of the access order (most recently used).
+// Must be called with c.mu held.
+func (c *IPGeoCache) moveToEnd(ip string) {
+	for i, v := range c.accessOrder {
+		if v == ip {
+			c.accessOrder = append(c.accessOrder[:i], c.accessOrder[i+1:]...)
+			c.accessOrder = append(c.accessOrder, ip)
+			return
+		}
+	}
+}
+
+// Len returns the current number of entries in the cache.
+func (c *IPGeoCache) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.cache)
 }

--- a/internal/coord/relay.go
+++ b/internal/coord/relay.go
@@ -212,7 +212,7 @@ func (r *relayManager) RegisterPersistent(peerName string, conn *websocket.Conn)
 	pc := &persistentConn{
 		peerName:  peerName,
 		conn:      conn,
-		writeChan: make(chan []byte, 256), // Buffered channel to prevent blocking
+		writeChan: make(chan []byte, 128), // Buffered channel to prevent blocking
 		closeChan: make(chan struct{}),
 	}
 	r.persistent[peerName] = pc

--- a/internal/coord/server.go
+++ b/internal/coord/server.go
@@ -598,6 +598,11 @@ func (s *Server) handlePeerByName(w http.ResponseWriter, r *http.Request) {
 			s.holePunch.RemoveEndpoint(name)
 		}
 
+		// Clean up stats history for the peer
+		if s.statsHistory != nil {
+			s.statsHistory.CleanupPeer(name)
+		}
+
 		if !exists {
 			s.jsonError(w, "peer not found", http.StatusNotFound)
 			return


### PR DESCRIPTION
## Summary
- Add LRU eviction to geolocation cache (max 1000 entries) to prevent unbounded growth
- Call CleanupPeer on peer deregister to free stats history (~3MB per peer)
- Add --pprof-addr flag for memory profiling (disabled by default)
- Reduce relay write buffer from 256 to 128
- Expose pprof in docker-compose via PPROF_ADDR env var
- Add LOG_LEVEL env var support in docker entrypoint

## Problem
Server was using 687MB vs ~50MB for clients (~14x more). Main causes:
- Unbounded geolocation cache growing indefinitely
- Stats history not cleaned up when peers disconnect
- No way to profile memory issues

## Test plan
- [x] All tests pass including new LRU eviction test
- [x] Lint passes
- [ ] Manual test with docker-compose: verify pprof accessible at localhost:6060

🤖 Generated with [Claude Code](https://claude.com/claude-code)