### PR TITLE
Update documentation for context management

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ For a complete step-by-step setup guide including downloading releases, configur
 
 ## Documentation
 
-- **[Getting Started Guide](docs/GETTING_STARTED.md)** - Installation, configuration, and running as a service
-- **[CLI Reference](docs/CLI.md)** - Complete command-line reference with examples and walkthroughs
+- **[Getting Started Guide](docs/GETTING_STARTED.md)** - Installation, configuration, contexts, and running as a service
+- **[CLI Reference](docs/CLI.md)** - Complete command-line reference including context management
 - **[WireGuard Integration](docs/WIREGUARD.md)** - Connect mobile devices and standard WireGuard clients
 - **[Docker Deployment](docs/DOCKER.md)** - Running TunnelMesh in containers for development and production
 - **[Cloud Deployment](docs/CLOUD_DEPLOYMENT.md)** - Deploy to DigitalOcean with Terraform (includes deployment scenarios)
@@ -342,19 +342,23 @@ tunnelmesh init                    # Generate SSH keys
 # Run coordination server
 sudo tunnelmesh serve -c server.yaml
 
-# Join mesh as peer
-sudo tunnelmesh join -c peer.yaml
+# Join mesh as peer (saves config as named context)
+sudo tunnelmesh join -c peer.yaml --context home
 
-# Check status
+# Manage contexts
+tunnelmesh context list            # List all contexts
+tunnelmesh context use work        # Switch active context
+
+# Check status (uses active context)
 tunnelmesh status                  # Connection status
 tunnelmesh peers                   # List all peers
 
-# System service
-sudo tunnelmesh service install --mode join -c /etc/tunnelmesh/peer.yaml
+# System service (uses active context)
+sudo tunnelmesh service install
 sudo tunnelmesh service start
 ```
 
-Most commands require a config file (`-c` flag) or one in a default location (`~/.tunnelmesh/config.yaml`, `peer.yaml`).
+**Context management:** After joining with `--context`, TunnelMesh remembers your configuration. Commands automatically use the active context—no need to specify `-c` every time.
 
 See **[CLI Reference](docs/CLI.md)** for complete documentation, all flags, and walkthroughs.
 

--- a/docs/CLOUD_DEPLOYMENT.md
+++ b/docs/CLOUD_DEPLOYMENT.md
@@ -185,7 +185,7 @@ nodes = {
 
 On your local machine:
 ```bash
-tunnelmesh join --exit-node tm-exit-sgp
+sudo tunnelmesh join --config peer.yaml --exit-node tm-exit-sgp --context work
 ```
 
 ---
@@ -322,6 +322,13 @@ dns:
     - "homeassistant"
 ```
 
+On the home server:
+```bash
+sudo tunnelmesh join --config peer.yaml --context homelab
+sudo tunnelmesh service install
+sudo tunnelmesh service start
+```
+
 ---
 
 ### Scenario 6: Development Team Secure Mesh
@@ -367,10 +374,11 @@ nodes = {
 
 Each developer runs:
 ```bash
-tunnelmesh join \
+sudo tunnelmesh join \
   --server https://tunnelmesh.example.com \
   --token team-token \
-  --name $(whoami)
+  --name $(whoami) \
+  --context team
 ```
 
 ---
@@ -421,7 +429,11 @@ nodes = {
 Players join from their gaming PCs:
 ```bash
 # Automatic UDP hole-punching for lowest latency
-tunnelmesh join --server https://tunnelmesh.example.com --name player1
+sudo tunnelmesh join \
+  --server https://tunnelmesh.example.com \
+  --token game-token \
+  --name player1 \
+  --context gaming
 ```
 
 ---

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -111,6 +111,8 @@ services:
 
 ## Configuration
 
+> **Note:** Context management (`tunnelmesh context`) is designed for host-based installations where you run multiple meshes from one machine. In Docker deployments, each container is typically dedicated to a single mesh and receives its config directly via volume mount or environment variables.
+
 ### Server Configuration
 
 Create `docker/config/server.yaml`:

--- a/docs/WIREGUARD.md
+++ b/docs/WIREGUARD.md
@@ -51,8 +51,11 @@ sudo tunnelmesh join \
   --server https://tunnelmesh.example.com \
   --token your-token \
   --name wg-gateway \
-  --wireguard
+  --wireguard \
+  --context wg-gateway
 ```
+
+This creates a context named "wg-gateway" that you can manage with `tunnelmesh context` commands.
 
 Or in config:
 ```yaml


### PR DESCRIPTION
## Summary
- Add full `tunnelmesh context` command documentation to CLI reference
- Update service commands documentation (removed `--name`, added `--context`)
- Add context management workflow to Getting Started guide
- Update all join examples to use `--context` flag
- Add context note to Docker deployment docs
- Update WireGuard quick start with context usage
- Update README CLI quick reference for context-based workflow

## Changes by file
- **docs/CLI.md**: Added complete context command docs, removed `--name` flag, updated service examples
- **docs/GETTING_STARTED.md**: Added "Managing Multiple Contexts" section, updated service install workflow
- **docs/CLOUD_DEPLOYMENT.md**: Updated join examples with `--context` flag
- **docs/DOCKER.md**: Added note that contexts are for host installations
- **docs/WIREGUARD.md**: Added `--context` to quick start example
- **README.md**: Updated CLI quick reference for context workflow

## Test plan
- [x] Documentation builds correctly
- [x] Examples are consistent across all docs
- [ ] Manual review of updated docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)