### PR TITLE
Fetch and store CA certificate locally during join

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all build build-force test test-verbose test-coverage test-js test-js-coverage test-all clean install lint fmt hooks hooks-install \
         dev-server dev-peer gen-keys release release-all push-release \
-        docker-build docker-up docker-down docker-logs docker-clean docker-test \
+        docker-build docker-up docker-down docker-logs docker-clean docker-test docker-admin \
         ghcr-login ghcr-build ghcr-push deploy deploy-plan deploy-destroy deploy-taint-coordinator \
         deploy-update deploy-update-node \
         service-install service-uninstall service-start service-stop service-status
@@ -187,7 +187,21 @@ docker-up: docker-build
 	@echo "=== Join from this machine ==="
 	@echo "sudo ./bin/tunnelmesh join --server http://localhost:8081 --token docker-test-token-123 --context docker"
 	@echo ""
-	@echo "Admin panel accessible at https://server-node.tunnelmesh/ from within the mesh"
+	@echo "After joining, run 'make docker-admin' to open the admin panel"
+
+docker-admin:
+	@echo "Waiting for admin panel at https://this.tunnelmesh/ ..."
+	@for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30; do \
+		if curl -sk --connect-timeout 2 https://this.tunnelmesh/ >/dev/null 2>&1; then \
+			echo "Admin panel ready, opening..."; \
+			open https://this.tunnelmesh/; \
+			exit 0; \
+		fi; \
+		echo -n "."; \
+		sleep 1; \
+	done; \
+	echo ""; \
+	echo "Timed out waiting for admin panel. Make sure you've joined the mesh first."
 
 docker-down:
 	$(DOCKER_COMPOSE) down

--- a/internal/peer/tls.go
+++ b/internal/peer/tls.go
@@ -36,6 +36,11 @@ func (m *TLSManager) KeyPath() string {
 	return filepath.Join(m.tlsDir(), "key.pem")
 }
 
+// CAPath returns the path to the CA certificate file.
+func (m *TLSManager) CAPath() string {
+	return filepath.Join(m.tlsDir(), "ca.pem")
+}
+
 // StoreCert saves the certificate and private key to disk.
 func (m *TLSManager) StoreCert(certPEM, keyPEM []byte) error {
 	// Ensure directory exists
@@ -58,6 +63,22 @@ func (m *TLSManager) StoreCert(certPEM, keyPEM []byte) error {
 		Str("key", m.KeyPath()).
 		Msg("stored TLS certificate")
 
+	return nil
+}
+
+// StoreCA saves the CA certificate to disk.
+func (m *TLSManager) StoreCA(caPEM []byte) error {
+	// Ensure directory exists
+	if err := os.MkdirAll(m.tlsDir(), 0755); err != nil {
+		return fmt.Errorf("create tls dir: %w", err)
+	}
+
+	// Save CA certificate
+	if err := os.WriteFile(m.CAPath(), caPEM, 0644); err != nil {
+		return fmt.Errorf("write ca: %w", err)
+	}
+
+	log.Debug().Str("ca", m.CAPath()).Msg("stored CA certificate")
 	return nil
 }
 

--- a/internal/peer/tls_test.go
+++ b/internal/peer/tls_test.go
@@ -1,0 +1,75 @@
+package peer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTLSManager_CAPath(t *testing.T) {
+	mgr := NewTLSManager("/tmp/test")
+	expected := filepath.Join("/tmp/test", "tls", "ca.pem")
+	if got := mgr.CAPath(); got != expected {
+		t.Errorf("CAPath() = %q, want %q", got, expected)
+	}
+}
+
+func TestTLSManager_StoreCA(t *testing.T) {
+	// Create temp directory
+	tmpDir, err := os.MkdirTemp("", "tls-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	mgr := NewTLSManager(tmpDir)
+	caPEM := []byte("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n")
+
+	// Store CA
+	if err := mgr.StoreCA(caPEM); err != nil {
+		t.Fatalf("StoreCA() error = %v", err)
+	}
+
+	// Verify file exists
+	caPath := mgr.CAPath()
+	if _, err := os.Stat(caPath); os.IsNotExist(err) {
+		t.Errorf("CA file not created at %s", caPath)
+	}
+
+	// Verify contents
+	got, err := os.ReadFile(caPath)
+	if err != nil {
+		t.Fatalf("failed to read CA file: %v", err)
+	}
+	if string(got) != string(caPEM) {
+		t.Errorf("CA content = %q, want %q", got, caPEM)
+	}
+
+	// Verify TLS directory was created
+	tlsDir := filepath.Join(tmpDir, "tls")
+	if _, err := os.Stat(tlsDir); os.IsNotExist(err) {
+		t.Errorf("TLS directory not created at %s", tlsDir)
+	}
+}
+
+func TestTLSManager_StoreCA_CreatesDirectory(t *testing.T) {
+	// Create temp directory and immediately remove it to test creation
+	tmpDir, err := os.MkdirTemp("", "tls-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	_ = os.RemoveAll(tmpDir) // Remove so StoreCA has to create it
+
+	mgr := NewTLSManager(tmpDir)
+	caPEM := []byte("test-ca")
+
+	if err := mgr.StoreCA(caPEM); err != nil {
+		t.Fatalf("StoreCA() error = %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Verify directory was created
+	if _, err := os.Stat(mgr.CAPath()); os.IsNotExist(err) {
+		t.Errorf("CA file not created")
+	}
+}


### PR DESCRIPTION
## Summary
- Fetch and store CA certificate locally when joining a mesh
- Prompt to install CA in system trust store during join (for browser HTTPS)
- Remove `trust-ca` CLI command (CA install now happens automatically)
- Clean up TLS certs and CA on `context delete` and `leave`
- Add `make docker-admin` target to open admin panel after joining

## Changes

### TLS/CA Management
- Add `CAPath()` and `StoreCA()` methods to TLSManager
- Add `FetchCA()` function to fetch CA PEM from server
- Store CA locally at `~/.tunnelmesh/tls/ca.pem` during join
- Prompt user to install CA in system keychain during join
- Remove standalone `trust-ca` command (functionality merged into join)

### Cleanup/Housekeeping
- Remove TLS directory on `context delete` (with user confirmation)
- Remove TLS directory on `leave` command
- Prompt to remove CA from system trust store on delete/leave
- Works on macOS, Linux, and Windows

### Docker
- Add `make docker-admin` target that waits for admin panel and opens it
- Update `make docker-up` to show instructions for joining first

## Test plan
- [x] All tests pass (ubuntu, macos, windows)
- [x] Build passes
- [ ] Join mesh and verify `~/.tunnelmesh/tls/ca.pem` is created
- [ ] Verify CA install prompt appears during join
- [ ] Test `context delete` removes TLS files and prompts for CA removal
- [ ] Test `leave` removes TLS files and prompts for CA removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)