### PR TITLE
Remove CA certificate confirmation prompts

### DIFF
--- a/cmd/tunnelmesh/context.go
+++ b/cmd/tunnelmesh/context.go
@@ -354,17 +354,12 @@ func runContextDelete(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Prompt to remove CA from system trust store
+	// Remove CA from system trust store
 	if trusted, _ := IsCATrusted(); trusted {
-		fmt.Print("Remove CA certificate from system trust store? [y/N]: ")
-		response, _ := reader.ReadString('\n')
-		response = strings.TrimSpace(strings.ToLower(response))
-		if response == "y" || response == "yes" {
-			if err := RemoveCA(); err != nil {
-				fmt.Printf("Warning: failed to remove CA certificate: %v\n", err)
-			} else {
-				fmt.Printf("CA certificate removed from system trust store.\n")
-			}
+		if err := RemoveCA(); err != nil {
+			fmt.Printf("Warning: failed to remove CA certificate: %v\n", err)
+		} else {
+			fmt.Printf("CA certificate removed from system trust store.\n")
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Auto-install CA certificate on join without prompting
- Auto-remove CA certificate on leave/context delete without prompting

## Changes
- Removed interactive prompts for CA install/reinstall during `tunnelmesh join`
- Removed interactive prompts for CA removal during `tunnelmesh leave` and `tunnelmesh context delete`
- CA operations now run automatically with warnings logged on failure

## Test plan
- [x] Build succeeds
- [x] All tests pass
- [ ] Test join command auto-installs CA
- [ ] Test leave command auto-removes CA
- [ ] Test context delete auto-removes CA

🤖 Generated with [Claude Code](https://claude.com/claude-code)