### PR TITLE
Add object-level prefix permissions to S3 authorization

### DIFF
--- a/internal/auth/authorizer_test.go
+++ b/internal/auth/authorizer_test.go
@@ -11,7 +11,7 @@ func TestAuthorizerDenyByDefault(t *testing.T) {
 	auth := NewAuthorizer()
 
 	// No bindings = deny
-	allowed := auth.Authorize("alice", "get", "buckets", "")
+	allowed := auth.Authorize("alice", "get", "buckets", "", "")
 	assert.False(t, allowed)
 }
 
@@ -22,9 +22,9 @@ func TestAuthorizerAdminAccess(t *testing.T) {
 	auth.Bindings.Add(NewRoleBinding("alice", RoleAdmin, ""))
 
 	// Admin can do anything
-	assert.True(t, auth.Authorize("alice", "get", "buckets", ""))
-	assert.True(t, auth.Authorize("alice", "delete", "objects", "my-bucket"))
-	assert.True(t, auth.Authorize("alice", "put", "objects", "any-bucket"))
+	assert.True(t, auth.Authorize("alice", "get", "buckets", "", ""))
+	assert.True(t, auth.Authorize("alice", "delete", "objects", "my-bucket", ""))
+	assert.True(t, auth.Authorize("alice", "put", "objects", "any-bucket", ""))
 }
 
 func TestAuthorizerBucketReadAccess(t *testing.T) {
@@ -33,12 +33,12 @@ func TestAuthorizerBucketReadAccess(t *testing.T) {
 	auth.Bindings.Add(NewRoleBinding("bob", RoleBucketRead, ""))
 
 	// Can read
-	assert.True(t, auth.Authorize("bob", "get", "buckets", ""))
-	assert.True(t, auth.Authorize("bob", "list", "objects", "my-bucket"))
+	assert.True(t, auth.Authorize("bob", "get", "buckets", "", ""))
+	assert.True(t, auth.Authorize("bob", "list", "objects", "my-bucket", ""))
 
 	// Cannot write or delete
-	assert.False(t, auth.Authorize("bob", "put", "objects", "my-bucket"))
-	assert.False(t, auth.Authorize("bob", "delete", "buckets", "my-bucket"))
+	assert.False(t, auth.Authorize("bob", "put", "objects", "my-bucket", ""))
+	assert.False(t, auth.Authorize("bob", "delete", "buckets", "my-bucket", ""))
 }
 
 func TestAuthorizerScopedBinding(t *testing.T) {
@@ -48,10 +48,10 @@ func TestAuthorizerScopedBinding(t *testing.T) {
 	auth.Bindings.Add(NewRoleBinding("bob", RoleBucketWrite, "my-bucket"))
 
 	// Can write to my-bucket
-	assert.True(t, auth.Authorize("bob", "put", "objects", "my-bucket"))
+	assert.True(t, auth.Authorize("bob", "put", "objects", "my-bucket", ""))
 
 	// Cannot write to other-bucket
-	assert.False(t, auth.Authorize("bob", "put", "objects", "other-bucket"))
+	assert.False(t, auth.Authorize("bob", "put", "objects", "other-bucket", ""))
 }
 
 func TestAuthorizerSystemBucketAccess(t *testing.T) {
@@ -61,11 +61,11 @@ func TestAuthorizerSystemBucketAccess(t *testing.T) {
 	auth.Bindings.Add(NewRoleBinding("svc:coordinator", RoleSystem, ""))
 
 	// Can access system bucket
-	assert.True(t, auth.Authorize("svc:coordinator", "put", "objects", "_tunnelmesh"))
-	assert.True(t, auth.Authorize("svc:coordinator", "get", "objects", "_tunnelmesh"))
+	assert.True(t, auth.Authorize("svc:coordinator", "put", "objects", "_tunnelmesh", ""))
+	assert.True(t, auth.Authorize("svc:coordinator", "get", "objects", "_tunnelmesh", ""))
 
 	// Cannot access other buckets
-	assert.False(t, auth.Authorize("svc:coordinator", "get", "objects", "user-bucket"))
+	assert.False(t, auth.Authorize("svc:coordinator", "get", "objects", "user-bucket", ""))
 }
 
 func TestAuthorizerMultipleBindings(t *testing.T) {
@@ -76,11 +76,11 @@ func TestAuthorizerMultipleBindings(t *testing.T) {
 	auth.Bindings.Add(NewRoleBinding("alice", RoleBucketWrite, "bucket2"))
 
 	// Can read bucket1
-	assert.True(t, auth.Authorize("alice", "get", "objects", "bucket1"))
-	assert.False(t, auth.Authorize("alice", "put", "objects", "bucket1"))
+	assert.True(t, auth.Authorize("alice", "get", "objects", "bucket1", ""))
+	assert.False(t, auth.Authorize("alice", "put", "objects", "bucket1", ""))
 
 	// Can write bucket2
-	assert.True(t, auth.Authorize("alice", "put", "objects", "bucket2"))
+	assert.True(t, auth.Authorize("alice", "put", "objects", "bucket2", ""))
 }
 
 func TestAuthorizerIsAdmin(t *testing.T) {
@@ -117,8 +117,8 @@ func TestNewAuthorizerWithRoles(t *testing.T) {
 	auth := NewAuthorizerWithRoles([]Role{customRole})
 	auth.Bindings.Add(NewRoleBinding("alice", "custom", ""))
 
-	assert.True(t, auth.Authorize("alice", "get", "buckets", ""))
-	assert.False(t, auth.Authorize("alice", "delete", "buckets", ""))
+	assert.True(t, auth.Authorize("alice", "get", "buckets", "", ""))
+	assert.False(t, auth.Authorize("alice", "delete", "buckets", "", ""))
 }
 
 func TestAuthorizerGetUserRoles(t *testing.T) {
@@ -151,14 +151,14 @@ func TestAuthorizer_AuthorizeWithGroups(t *testing.T) {
 	auth.GroupBindings.Add(NewGroupBinding("developers", RoleBucketRead, ""))
 
 	// Alice should have read access via group membership
-	assert.True(t, auth.Authorize("alice", "get", "objects", "any-bucket"))
-	assert.True(t, auth.Authorize("alice", "list", "objects", "any-bucket"))
+	assert.True(t, auth.Authorize("alice", "get", "objects", "any-bucket", ""))
+	assert.True(t, auth.Authorize("alice", "list", "objects", "any-bucket", ""))
 
 	// Alice should not have write access
-	assert.False(t, auth.Authorize("alice", "put", "objects", "any-bucket"))
+	assert.False(t, auth.Authorize("alice", "put", "objects", "any-bucket", ""))
 
 	// Bob is not in the group, should be denied
-	assert.False(t, auth.Authorize("bob", "get", "objects", "any-bucket"))
+	assert.False(t, auth.Authorize("bob", "get", "objects", "any-bucket", ""))
 }
 
 func TestAuthorizer_AuthorizeWithScopedGroupBinding(t *testing.T) {
@@ -171,10 +171,10 @@ func TestAuthorizer_AuthorizeWithScopedGroupBinding(t *testing.T) {
 	auth.GroupBindings.Add(NewGroupBinding(GroupEveryone, RoleBucketRead, "fs+data"))
 
 	// Alice can read fs+data
-	assert.True(t, auth.Authorize("alice", "get", "objects", "fs+data"))
+	assert.True(t, auth.Authorize("alice", "get", "objects", "fs+data", ""))
 
 	// Alice cannot read other buckets via this binding
-	assert.False(t, auth.Authorize("alice", "get", "objects", "other-bucket"))
+	assert.False(t, auth.Authorize("alice", "get", "objects", "other-bucket", ""))
 }
 
 func TestAuthorizer_UserBindingTakesPrecedence(t *testing.T) {
@@ -188,7 +188,7 @@ func TestAuthorizer_UserBindingTakesPrecedence(t *testing.T) {
 	auth.GroupBindings.Add(NewGroupBinding("readers", RoleBucketRead, ""))
 
 	// Alice should have admin access (from direct binding)
-	assert.True(t, auth.Authorize("alice", "delete", "buckets", "any-bucket"))
+	assert.True(t, auth.Authorize("alice", "delete", "buckets", "any-bucket", ""))
 }
 
 func TestAuthorizer_IsAdmin_ViaGroup(t *testing.T) {
@@ -214,11 +214,11 @@ func TestAuthorizer_ServiceUsersViaGroup(t *testing.T) {
 	auth.GroupBindings.Add(NewGroupBinding(GroupAllServiceUsers, RoleSystem, ""))
 
 	// Service user should access _tunnelmesh bucket
-	assert.True(t, auth.Authorize("svc:coordinator", "put", "objects", "_tunnelmesh"))
-	assert.True(t, auth.Authorize("svc:coordinator", "get", "objects", "_tunnelmesh"))
+	assert.True(t, auth.Authorize("svc:coordinator", "put", "objects", "_tunnelmesh", ""))
+	assert.True(t, auth.Authorize("svc:coordinator", "get", "objects", "_tunnelmesh", ""))
 
 	// But not other buckets
-	assert.False(t, auth.Authorize("svc:coordinator", "get", "objects", "user-bucket"))
+	assert.False(t, auth.Authorize("svc:coordinator", "get", "objects", "user-bucket", ""))
 }
 
 func TestAuthorizer_GroupBindingPrecedence(t *testing.T) {
@@ -236,8 +236,8 @@ func TestAuthorizer_GroupBindingPrecedence(t *testing.T) {
 	auth.GroupBindings.Add(NewGroupBinding("writers", RoleBucketWrite, ""))
 
 	// Alice should have both read and write access
-	assert.True(t, auth.Authorize("alice", "get", "objects", "any-bucket"))
-	assert.True(t, auth.Authorize("alice", "put", "objects", "any-bucket"))
+	assert.True(t, auth.Authorize("alice", "get", "objects", "any-bucket", ""))
+	assert.True(t, auth.Authorize("alice", "put", "objects", "any-bucket", ""))
 }
 
 func TestAuthorizer_HasHumanAdmin_ViaGroup(t *testing.T) {
@@ -252,4 +252,142 @@ func TestAuthorizer_HasHumanAdmin_ViaGroup(t *testing.T) {
 	// Add human user to admin group
 	_ = auth.Groups.AddMember(GroupAllAdminUsers, "alice")
 	assert.True(t, auth.HasHumanAdmin())
+}
+
+// --- Object-level prefix authorization tests ---
+
+func TestAuthorizer_ObjectPrefix(t *testing.T) {
+	auth := NewAuthorizer()
+
+	// User with prefix-scoped write access
+	binding := NewRoleBinding("alice", RoleBucketWrite, "projects")
+	binding.ObjectPrefix = "teamA/"
+	auth.Bindings.Add(binding)
+
+	tests := []struct {
+		name   string
+		userID string
+		verb   string
+		bucket string
+		key    string
+		want   bool
+	}{
+		{"can write to teamA", "alice", "put", "projects", "teamA/doc.txt", true},
+		{"can write nested", "alice", "put", "projects", "teamA/sub/doc.txt", true},
+		{"cannot write to teamB", "alice", "put", "projects", "teamB/doc.txt", false},
+		{"cannot write to root", "alice", "put", "projects", "doc.txt", false},
+		{"can list bucket (empty key)", "alice", "list", "projects", "", true},
+		{"can get from teamA", "alice", "get", "projects", "teamA/file.txt", true},
+		{"cannot get from teamB", "alice", "get", "projects", "teamB/file.txt", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := auth.Authorize(tt.userID, tt.verb, "objects", tt.bucket, tt.key)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAuthorizer_ObjectPrefix_Group(t *testing.T) {
+	auth := NewAuthorizerWithGroups()
+
+	// Create group and add user
+	_, _ = auth.Groups.Create("teamA", "Team A developers")
+	_ = auth.Groups.AddMember("teamA", "alice")
+
+	// Grant teamA group access to projects/teamA/ prefix
+	binding := NewGroupBinding("teamA", RoleBucketWrite, "projects")
+	binding.ObjectPrefix = "teamA/"
+	auth.GroupBindings.Add(binding)
+
+	// Alice (via group) can write to teamA/
+	assert.True(t, auth.Authorize("alice", "put", "objects", "projects", "teamA/doc.txt"))
+
+	// Alice cannot write to teamB/
+	assert.False(t, auth.Authorize("alice", "put", "objects", "projects", "teamB/doc.txt"))
+
+	// Bob (not in group) cannot write to teamA/
+	assert.False(t, auth.Authorize("bob", "put", "objects", "projects", "teamA/doc.txt"))
+}
+
+func TestAuthorizer_ObjectPrefix_MultipleBindings(t *testing.T) {
+	auth := NewAuthorizer()
+
+	// Alice has access to two different prefixes
+	bindingA := NewRoleBinding("alice", RoleBucketWrite, "projects")
+	bindingA.ObjectPrefix = "teamA/"
+	auth.Bindings.Add(bindingA)
+
+	bindingB := NewRoleBinding("alice", RoleBucketRead, "projects")
+	bindingB.ObjectPrefix = "shared/"
+	auth.Bindings.Add(bindingB)
+
+	// Can write to teamA
+	assert.True(t, auth.Authorize("alice", "put", "objects", "projects", "teamA/doc.txt"))
+
+	// Can read from shared
+	assert.True(t, auth.Authorize("alice", "get", "objects", "projects", "shared/doc.txt"))
+
+	// Cannot write to shared (only read access)
+	assert.False(t, auth.Authorize("alice", "put", "objects", "projects", "shared/doc.txt"))
+
+	// Cannot access teamC
+	assert.False(t, auth.Authorize("alice", "get", "objects", "projects", "teamC/doc.txt"))
+}
+
+func TestAuthorizer_GetAllowedPrefixes(t *testing.T) {
+	auth := NewAuthorizer()
+
+	// Alice has access to two prefixes in projects bucket
+	bindingA := NewRoleBinding("alice", RoleBucketWrite, "projects")
+	bindingA.ObjectPrefix = "teamA/"
+	auth.Bindings.Add(bindingA)
+
+	bindingB := NewRoleBinding("alice", RoleBucketRead, "projects")
+	bindingB.ObjectPrefix = "shared/"
+	auth.Bindings.Add(bindingB)
+
+	// Bob has unrestricted access to projects
+	auth.Bindings.Add(NewRoleBinding("bob", RoleBucketAdmin, "projects"))
+
+	// Alice should get list of prefixes she can access
+	prefixes := auth.GetAllowedPrefixes("alice", "projects")
+	require.NotNil(t, prefixes)
+	assert.Len(t, prefixes, 2)
+	assert.Contains(t, prefixes, "teamA/")
+	assert.Contains(t, prefixes, "shared/")
+
+	// Bob has unrestricted access, should return nil
+	prefixes = auth.GetAllowedPrefixes("bob", "projects")
+	assert.Nil(t, prefixes)
+
+	// Charlie has no access, should return empty slice
+	prefixes = auth.GetAllowedPrefixes("charlie", "projects")
+	require.NotNil(t, prefixes)
+	assert.Empty(t, prefixes)
+}
+
+func TestAuthorizer_GetAllowedPrefixes_WithGroups(t *testing.T) {
+	auth := NewAuthorizerWithGroups()
+
+	// Alice is in teamA group
+	_, _ = auth.Groups.Create("teamA", "")
+	_ = auth.Groups.AddMember("teamA", "alice")
+
+	// teamA group has access to teamA/ prefix
+	binding := NewGroupBinding("teamA", RoleBucketWrite, "projects")
+	binding.ObjectPrefix = "teamA/"
+	auth.GroupBindings.Add(binding)
+
+	// Alice also has direct access to shared/
+	directBinding := NewRoleBinding("alice", RoleBucketRead, "projects")
+	directBinding.ObjectPrefix = "shared/"
+	auth.Bindings.Add(directBinding)
+
+	prefixes := auth.GetAllowedPrefixes("alice", "projects")
+	require.NotNil(t, prefixes)
+	assert.Len(t, prefixes, 2)
+	assert.Contains(t, prefixes, "teamA/")
+	assert.Contains(t, prefixes, "shared/")
 }

--- a/internal/auth/group_binding_test.go
+++ b/internal/auth/group_binding_test.go
@@ -59,6 +59,54 @@ func TestGroupBinding_AppliesToBucket(t *testing.T) {
 	}
 }
 
+func TestGroupBinding_AppliesToObject(t *testing.T) {
+	tests := []struct {
+		name         string
+		bucketScope  string
+		objectPrefix string
+		bucket       string
+		key          string
+		want         bool
+	}{
+		// No scope = applies to everything
+		{"no scope, any bucket/key", "", "", "mybucket", "any/key.txt", true},
+		{"no scope, empty key", "", "", "mybucket", "", true},
+
+		// Bucket scope only (no prefix)
+		{"bucket match, no prefix", "mybucket", "", "mybucket", "any/key.txt", true},
+		{"bucket match, empty key", "mybucket", "", "mybucket", "", true},
+		{"bucket mismatch", "mybucket", "", "other", "any/key.txt", false},
+
+		// Prefix scope
+		{"prefix match", "mybucket", "projects/teamA/", "mybucket", "projects/teamA/file.txt", true},
+		{"prefix match nested", "mybucket", "projects/", "mybucket", "projects/teamA/sub/file.txt", true},
+		{"prefix mismatch", "mybucket", "projects/teamA/", "mybucket", "projects/teamB/file.txt", false},
+		{"prefix exact match", "mybucket", "config.json", "mybucket", "config.json", true},
+		{"prefix partial mismatch", "mybucket", "projects/teamA/", "mybucket", "projects/teamABC/file.txt", false},
+
+		// Empty key (bucket-level operations like list) - always passes prefix check
+		{"empty key with prefix", "mybucket", "projects/", "mybucket", "", true},
+
+		// Bucket mismatch with prefix
+		{"bucket mismatch with prefix", "mybucket", "projects/", "other", "projects/file.txt", false},
+
+		// No bucket scope but with prefix (applies to all buckets with that prefix)
+		{"no bucket scope with prefix", "", "shared/", "anybucket", "shared/file.txt", true},
+		{"no bucket scope prefix mismatch", "", "shared/", "anybucket", "private/file.txt", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			binding := GroupBinding{
+				BucketScope:  tt.bucketScope,
+				ObjectPrefix: tt.objectPrefix,
+			}
+			got := binding.AppliesToObject(tt.bucket, tt.key)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestGroupBindingStore_Add(t *testing.T) {
 	store := NewGroupBindingStore()
 	require.NotNil(t, store)

--- a/internal/coord/s3/auth_test.go
+++ b/internal/coord/s3/auth_test.go
@@ -140,7 +140,7 @@ func TestRBACAuthorizerAuthorize(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer "+accessKey)
 
-	userID, err := rbac.AuthorizeRequest(req, "get", "buckets", "")
+	userID, err := rbac.AuthorizeRequest(req, "get", "buckets", "", "")
 	require.NoError(t, err)
 	assert.Equal(t, "alice", userID)
 }
@@ -158,7 +158,7 @@ func TestRBACAuthorizerBasicAuth(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/my-bucket", nil)
 	req.SetBasicAuth(accessKey, secretKey)
 
-	userID, err := rbac.AuthorizeRequest(req, "get", "buckets", "my-bucket")
+	userID, err := rbac.AuthorizeRequest(req, "get", "buckets", "my-bucket", "")
 	require.NoError(t, err)
 	assert.Equal(t, "bob", userID)
 }
@@ -170,7 +170,7 @@ func TestRBACAuthorizerDeniedNoAuth(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 
-	_, err := rbac.AuthorizeRequest(req, "get", "buckets", "")
+	_, err := rbac.AuthorizeRequest(req, "get", "buckets", "", "")
 	assert.ErrorIs(t, err, ErrAccessDenied)
 }
 
@@ -182,7 +182,7 @@ func TestRBACAuthorizerDeniedUnknownUser(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer unknownaccesskey")
 
-	_, err := rbac.AuthorizeRequest(req, "get", "buckets", "")
+	_, err := rbac.AuthorizeRequest(req, "get", "buckets", "", "")
 	assert.ErrorIs(t, err, ErrAccessDenied)
 }
 
@@ -199,7 +199,7 @@ func TestRBACAuthorizerDeniedNoPermission(t *testing.T) {
 	req := httptest.NewRequest(http.MethodDelete, "/my-bucket", nil)
 	req.Header.Set("Authorization", "Bearer "+accessKey)
 
-	_, err = rbac.AuthorizeRequest(req, "delete", "buckets", "my-bucket")
+	_, err = rbac.AuthorizeRequest(req, "delete", "buckets", "my-bucket", "")
 	assert.ErrorIs(t, err, ErrAccessDenied)
 }
 
@@ -219,11 +219,11 @@ func TestRBACAuthorizerScopedPermission(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+accessKey)
 
 	// Can write to my-bucket
-	_, err = rbac.AuthorizeRequest(req, "put", "objects", "my-bucket")
+	_, err = rbac.AuthorizeRequest(req, "put", "objects", "my-bucket", "")
 	require.NoError(t, err)
 
 	// Cannot write to other-bucket
-	_, err = rbac.AuthorizeRequest(req, "put", "objects", "other-bucket")
+	_, err = rbac.AuthorizeRequest(req, "put", "objects", "other-bucket", "")
 	assert.ErrorIs(t, err, ErrAccessDenied)
 }
 
@@ -231,7 +231,7 @@ func TestAllowAllAuthorizer(t *testing.T) {
 	authz := &AllowAllAuthorizer{UserID: "test-user"}
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	userID, err := authz.AuthorizeRequest(req, "get", "buckets", "")
+	userID, err := authz.AuthorizeRequest(req, "get", "buckets", "", "")
 
 	require.NoError(t, err)
 	assert.Equal(t, "test-user", userID)

--- a/internal/coord/server_test.go
+++ b/internal/coord/server_test.go
@@ -1028,6 +1028,6 @@ func TestServer_S3UserRecoveryOnRestart(t *testing.T) {
 	assert.Equal(t, secretKey, recoveredSecret)
 
 	// Verify role bindings were recovered
-	canRead := srv2.s3Authorizer.Authorize(testUserID, "get", "objects", "test-bucket")
+	canRead := srv2.s3Authorizer.Authorize(testUserID, "get", "objects", "test-bucket", "")
 	assert.True(t, canRead, "user should have read permission after restart")
 }


### PR DESCRIPTION
## Summary
- Add `ObjectPrefix` field to `RoleBinding` and `GroupBinding` for granular object-level access control
- Update `Authorize()` to check object key against allowed prefixes with `strings.HasPrefix`
- Add `GetAllowedPrefixes()` method to retrieve user's allowed prefixes per bucket
- Filter list operations to only return objects the user can access
- Update S3 server `Authorizer` interface with `GetAllowedPrefixes` method

## Details
Users can now be granted access to specific object prefixes within buckets (e.g., `projects/teamA/*`). This enables team-based access control where different teams can only access their designated areas within a shared bucket.

Key behaviors:
- Empty `ObjectPrefix` = unrestricted access within bucket scope
- Empty object key (bucket-level operations) always passes prefix check
- List operations filter results to only show objects matching allowed prefixes
- `GetAllowedPrefixes` returns `nil` for unrestricted access, empty slice for no access

## Test plan
- [x] Unit tests for `RoleBinding.AppliesToObject`
- [x] Unit tests for `GroupBinding.AppliesToObject`
- [x] Unit tests for `Authorizer.Authorize` with object keys
- [x] Unit tests for `Authorizer.GetAllowedPrefixes`
- [x] Unit tests for list filtering (V1 and V2)
- [x] All existing tests pass
- [x] Linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)