### PR TITLE
Add tabbed navigation: Mesh | Data

### DIFF
--- a/internal/coord/web/css/style.css
+++ b/internal/coord/web/css/style.css
@@ -94,6 +94,53 @@ header h1 {
     color: var(--color-text-primary);
 }
 
+/* Tab Navigation */
+#main-tabs {
+    background: var(--color-bg-secondary);
+    border-bottom: 1px solid var(--color-border-primary);
+    display: flex;
+    justify-content: center;
+    padding: 0.5rem 0;
+}
+
+.tab-container {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.tab {
+    background: none;
+    border: none;
+    color: var(--color-text-secondary);
+    font-size: 0.875rem;
+    font-weight: 500;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    transition: color 0.15s ease;
+}
+
+.tab:hover {
+    color: var(--color-text-primary);
+}
+
+.tab.active {
+    color: var(--color-accent-blue);
+}
+
+.tab-separator {
+    color: var(--color-border-primary);
+    font-weight: 300;
+}
+
+.tab-content {
+    display: none;
+}
+
+.tab-content.active {
+    display: block;
+}
+
 /* Charts Section - matches main's width constraints */
 #charts-section {
     max-width: 1400px;

--- a/internal/coord/web/index.html
+++ b/internal/coord/web/index.html
@@ -41,6 +41,17 @@
         </div>
     </header>
 
+    <nav id="main-tabs">
+        <div class="tab-container">
+            <button class="tab active" data-tab="mesh">Mesh</button>
+            <span class="tab-separator">|</span>
+            <button class="tab" data-tab="data">Data</button>
+        </div>
+    </nav>
+
+    <!-- Mesh Tab Content -->
+    <div id="mesh-tab" class="tab-content active">
+
     <section id="alerts-section" style="display: none;">
         <div class="alert-tiles">
             <a class="alert-tile warning clickable-card" id="alert-tile-warning" href="/prometheus/alerts">
@@ -279,8 +290,13 @@
                 </div>
             </div>
         </section>
+    </main>
+    </div><!-- End Mesh Tab -->
 
-        <section id="users-section" style="display: none;">
+    <!-- Data Tab Content -->
+    <div id="data-tab" class="tab-content">
+    <main>
+        <section id="users-section">
             <div class="section-header section-toggle" onclick="toggleSection(this)">
                 <h2>Users</h2>
             </div>
@@ -304,7 +320,7 @@
             </div>
         </section>
 
-        <section id="groups-section" style="display: none;">
+        <section id="groups-section">
             <div class="section-header section-toggle" onclick="toggleSection(this)">
                 <h2>Groups</h2>
                 <button id="add-group-btn" class="btn-primary" onclick="event.stopPropagation(); openGroupModal();">+ Add Group</button>
@@ -328,7 +344,7 @@
             </div>
         </section>
 
-        <section id="shares-section" style="display: none;">
+        <section id="shares-section">
             <div class="section-header section-toggle" onclick="toggleSection(this)">
                 <h2>File Shares</h2>
                 <button id="add-share-btn" class="btn-primary" onclick="event.stopPropagation(); openShareModal();">+ New Share</button>
@@ -351,6 +367,34 @@
                 </div>
             </div>
         </section>
+
+        <section id="bindings-section">
+            <div class="section-header section-toggle" onclick="toggleSection(this)">
+                <h2>Role Bindings</h2>
+                <button id="add-binding-btn" class="btn-primary" onclick="event.stopPropagation(); openBindingModal();">+ Add Binding</button>
+            </div>
+            <div class="collapsible-content">
+                <table id="bindings">
+                    <thead>
+                        <tr>
+                            <th>User/Group</th>
+                            <th>Role</th>
+                            <th>Bucket Scope</th>
+                            <th>Object Prefix</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody id="bindings-body"></tbody>
+                </table>
+                <div id="no-bindings" class="empty-state" style="display: none;">
+                    No role bindings configured.
+                </div>
+            </div>
+        </section>
+    </main>
+    </div><!-- End Data Tab -->
+
+    <!-- Modals (outside tabs) -->
 
         <!-- Group Modal -->
         <div id="group-modal" class="modal" style="display: none;">
@@ -435,7 +479,43 @@
                 </div>
             </div>
         </div>
-    </main>
+
+        <!-- Binding Modal -->
+        <div id="binding-modal" class="modal" style="display: none;">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h3>Add Role Binding</h3>
+                    <button class="modal-close" onclick="closeBindingModal()">&times;</button>
+                </div>
+                <div class="modal-body">
+                    <div class="form-group">
+                        <label for="binding-user">User ID</label>
+                        <select id="binding-user">
+                            <option value="">Select a user...</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="binding-role">Role</label>
+                        <select id="binding-role">
+                            <option value="bucket-read">Read Only</option>
+                            <option value="bucket-write">Read/Write</option>
+                            <option value="bucket-admin">Admin</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="binding-bucket">Bucket Scope (optional)</label>
+                        <input type="text" id="binding-bucket" placeholder="e.g., fs+documents">
+                        <small class="form-hint">Leave empty to apply to all buckets</small>
+                    </div>
+                    <div class="form-group">
+                        <label for="binding-prefix">Object Prefix (optional)</label>
+                        <input type="text" id="binding-prefix" placeholder="e.g., projects/teamA/">
+                        <small class="form-hint">Restrict access to objects with this prefix</small>
+                    </div>
+                    <button class="btn-primary" onclick="createBinding()">Create Binding</button>
+                </div>
+            </div>
+        </div>
 
     <footer>
         <a href="https://github.com/zombar/tunnelmesh" class="footer-link">


### PR DESCRIPTION
## Summary
- Add centered tab navigation bar with discreet "Mesh | Data" tabs
- Move users, groups, file shares, and role bindings to Data tab
- Keep topology, charts, peers, DNS, WireGuard, filters on Mesh tab
- Add bindings section with full CRUD operations for role bindings
- Mesh tab is the default selection

## Changes
- `index.html`: Added `#main-tabs` nav with tab buttons, wrapped existing sections in `#mesh-tab`, created new `#data-tab` with users, groups, shares, and bindings sections
- `style.css`: Added tab styling with centered layout
- `app.js`: Added tab switching logic, `fetchBindings()`, `renderBindings()`, `openBindingModal()`, `createBinding()`, `deleteBinding()`

## Test plan
- [x] Tabs switch correctly between Mesh and Data views
- [x] Mesh tab shows topology, charts, peers, DNS, WireGuard, filters
- [x] Data tab shows users, groups, file shares, role bindings
- [x] Binding CRUD operations work (create, delete, list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)