### PR TITLE
Fix share bindings and Docker registration delay

### DIFF
--- a/docker/scripts/client-entrypoint.sh
+++ b/docker/scripts/client-entrypoint.sh
@@ -121,14 +121,14 @@ if [ ! -f "$USER_JSON" ]; then
     tunnelmesh user setup --name "$USER_NAME"
 fi
 
-# Register user in background after 10 minutes
+# Register user in background after 1 minute
 (
-    sleep 600  # Wait 10 minutes
+    sleep 60  # Wait 1 minute
     echo ""
     echo "=== Registering user with mesh ==="
     tunnelmesh user register --server "$SERVER_URL" || echo "User registration failed (may already be registered)"
 ) &
-echo "User registration scheduled in 10 minutes"
+echo "User registration scheduled in 1 minute"
 
 # Give time for initial peer discovery (Go code handles jitter and fast retries)
 echo "Waiting for initial peer discovery..."

--- a/internal/coord/web/js/app.js
+++ b/internal/coord/web/js/app.js
@@ -2300,6 +2300,7 @@ async function createShare() {
             showToast(`File share "${name}" created`, 'success');
             closeShareModal();
             fetchShares();
+            fetchBindings(); // Refresh bindings since share creation adds admin binding
         } else {
             const data = await resp.json();
             showToast(data.error || 'Failed to create share', 'error');
@@ -2318,6 +2319,7 @@ async function deleteShare(name) {
         if (resp.ok) {
             showToast(`File share "${name}" deleted`, 'success');
             fetchShares();
+            fetchBindings(); // Refresh bindings since share deletion removes bindings
         } else {
             const data = await resp.json();
             showToast(data.error || 'Failed to delete share', 'error');
@@ -2396,7 +2398,9 @@ function renderBindings(bindings) {
             <td>${escapeHtml(b.bucket_scope || 'All')}</td>
             <td>${escapeHtml(b.object_prefix || '-')}</td>
             <td>
-                <button class="btn-small btn-danger" onclick="deleteBinding('${escapeHtml(b.name)}')">Delete</button>
+                ${b.protected
+                    ? '<span class="text-muted" title="File share owner binding">Protected</span>'
+                    : `<button class="btn-small btn-danger" onclick="deleteBinding('${escapeHtml(b.name)}')">Delete</button>`}
             </td>
         </tr>
     `).join('');


### PR DESCRIPTION
## Summary
- Reduce Docker client registration delay from 10 minutes to 1 minute
- Refresh role bindings table when a file share is created or deleted
- Prevent deletion of file share owner admin bindings

## Changes

### Docker (`docker/scripts/client-entrypoint.sh`)
- Changed registration delay from 600s (10 min) to 60s (1 min)

### Backend (`internal/coord/`)
- Added `IsProtectedBinding()` method to `FileShareManager` to identify file share owner admin bindings
- API returns `protected: true` for protected bindings
- DELETE `/api/bindings/{name}` returns 403 Forbidden for protected bindings with helpful error message

### Frontend (`internal/coord/web/js/app.js`)
- Call `fetchBindings()` after creating/deleting a file share to refresh the table
- Show "Protected" label instead of delete button for owner admin bindings

## Test plan
- [x] All tests pass
- [x] Linter passes
- [x] Added `TestFileShareManager_IsProtectedBinding` with 5 test cases
- [ ] Verify bindings table refreshes after share creation
- [ ] Verify protected bindings show "Protected" instead of delete button
- [ ] Verify deleting protected binding returns error

🤖 Generated with [Claude Code](https://claude.com/claude-code)