### PR TITLE
Optimize test performance: Skip fsync during tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,13 @@ jobs:
           go-version: '1.25.7'
       - name: Run tests
         if: matrix.os != 'ubuntu-latest'
+        env:
+          TUNNELMESH_TEST: "1"
         run: go test -short -race ./...
       - name: Run tests with coverage
         if: matrix.os == 'ubuntu-latest'
+        env:
+          TUNNELMESH_TEST: "1"
         run: go test -short -race -coverprofile=coverage.out ./...
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request'
@@ -104,6 +108,8 @@ jobs:
           check-latest: true
       - name: Run tests
         if: steps.setup-go.outcome == 'success'
+        env:
+          TUNNELMESH_TEST: "1"
         run: go test -short -race ./...
       - name: Skip notice
         if: steps.setup-go.outcome != 'success'


### PR DESCRIPTION
## Problem

After adding fsync for production durability (#308), tests became very slow:
- **S3 package**: 179 tests × ~2s fsync overhead = **435s (7+ min) on Windows**
- **S3 tests**: 197s on Mac, 165s with `-short` (still too slow)
- **Total CI impact**: Significant slowdown across all platforms

## Solution

Skip fsync when `TUNNELMESH_TEST=1` environment variable is set:
- Tests use temporary directories that are discarded anyway
- Production code retains full fsync durability  
- No functional correctness impact (tests verify logic, not disk I/O)

## Expected Improvement

- **S3 tests**: 165s → ~10-20s (**90% faster**)
- **Windows CI**: Should complete in 2-3 minutes (down from 5+ minutes)
- **Linux/Mac**: Moderate improvement in overall test time

## Changes

1. **`internal/coord/s3/store.go`**: Modified `syncedWriteFile()` to skip fsync when `TUNNELMESH_TEST=1`
2. **`.github/workflows/ci.yml`**: Set `TUNNELMESH_TEST=1` for all test jobs

## Trade-offs

**With fsync per operation (production)**:
- ✅ Maximum durability - every write survives crash
- ⚠️ Lower throughput under heavy write load (acceptable for current usage)

**With test skip**:
- ✅ Fast test iteration
- ✅ Production maintains full durability
- ✅ Tests verify functional correctness

## Future Optimization

If production experiences write latency under heavy load, consider implementing WAL-style batching to reduce fsync frequency while maintaining durability guarantees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)