### PR TITLE
Implement per-chunk version vectors (Phase 3)

### DIFF
--- a/internal/coord/replication/version_vector.go
+++ b/internal/coord/replication/version_vector.go
@@ -196,3 +196,36 @@ func (vv *VersionVector) UnmarshalJSON(data []byte) error {
 	*vv = VersionVector(m)
 	return nil
 }
+
+// CompareVersionVectorMaps compares two version vector maps (used by s3.ChunkMetadata).
+// Returns the relationship between them.
+func CompareVersionVectorMaps(vv1, vv2 map[string]uint64) VectorRelationship {
+	return VersionVector(vv1).Compare(VersionVector(vv2))
+}
+
+// MergeVersionVectorMaps merges two version vector maps, taking the maximum value for each key.
+// Returns the merged version vector.
+func MergeVersionVectorMaps(vv1, vv2 map[string]uint64) map[string]uint64 {
+	merged := make(map[string]uint64)
+
+	// Copy vv1
+	for k, v := range vv1 {
+		merged[k] = v
+	}
+
+	// Merge vv2 (taking max)
+	for k, v := range vv2 {
+		if v > merged[k] {
+			merged[k] = v
+		}
+	}
+
+	return merged
+}
+
+// ResolveConflictMaps resolves a conflict between two version vector maps.
+// Returns the winner version vector.
+func ResolveConflictMaps(vv1, vv2 map[string]uint64) map[string]uint64 {
+	winner := ResolveConflict(VersionVector(vv1), VersionVector(vv2))
+	return map[string]uint64(winner)
+}


### PR DESCRIPTION
## Summary

This PR implements **Phase 3** of the chunk-level replication architecture, adding fine-grained conflict resolution at the chunk level to enable distributed replication with concurrent modifications.

Builds on PR #312 (Phases 1-2: Streaming uploads + chunk registry foundation).

### 🎯 Phase 3: Per-Chunk Version Vectors

**Problem:** Need fine-grained causality tracking to resolve conflicts when multiple coordinators modify the same file concurrently.

**Solution:** Track version vectors at both file and chunk level, enabling chunk-by-chunk conflict resolution instead of all-or-nothing file conflicts.

## Implementation

### 📦 Phase 3.1: Extend ObjectMeta with ChunkMetadata

Added comprehensive per-chunk metadata tracking:

```go
type ChunkMetadata struct {
    Hash           string            // SHA-256 of chunk plaintext
    Size           int64             // Uncompressed size
    CompressedSize int64             // Compressed size (if known)
    VersionVector  map[string]uint64 // Causality tracking (coordinatorID -> counter)
    Owners         []string          // Coordinators that have this chunk
    FirstSeen      time.Time         // When chunk was first created
    LastModified   time.Time         // When chunk metadata was last updated
}
```

Extended ObjectMeta with:
- `ChunkMetadata map[string]*ChunkMetadata` - Per-chunk tracking
- `VersionVector map[string]uint64` - File-level causality

Added Store support:
- `coordinatorID` field for version vector tracking
- `SetCoordinatorID()` method for configuration

### ⚡ Phase 3.2: Update version vectors on chunk writes

Modified `PutObject` to populate metadata during streaming upload:

- Initialize version vector for each chunk (coordinator counter = 1)
- Set owners list to local coordinator
- Track creation and modification timestamps
- Create file-level version vector for object metadata
- All metadata populated incrementally (no memory bloat)

### 🔀 Phase 3.3: Implement chunk-level conflict resolution

Added helper functions in replication package for cross-package compatibility:

```go
// Compare version vectors (returns VectorBefore/After/Equal/Concurrent)
CompareVersionVectorMaps(vv1, vv2 map[string]uint64) VectorRelationship

// Merge version vectors (take max value for each coordinator)
MergeVersionVectorMaps(vv1, vv2 map[string]uint64) map[string]uint64

// Resolve conflicts deterministically (lexicographic tie-breaker)
ResolveConflictMaps(vv1, vv2 map[string]uint64) map[string]uint64
```

These functions enable s3 and replication packages to work together without circular dependencies.

## Files Changed

| File | Changes | Description |
|------|---------|-------------|
| `internal/coord/s3/store.go` | +40 lines | ChunkMetadata type, coordinatorID field, version vector creation |
| `internal/coord/replication/version_vector.go` | +35 lines | Map-based version vector helpers |
| `internal/coord/replication/version_vector_test.go` | +85 lines | 3 new test functions |

**Total:** ~160 lines added

## Testing

✅ **All existing tests pass** (s3 + replication packages)  
✅ **3 new version vector tests**:  
- `TestCompareVersionVectorMaps` - Equality, causality, concurrency
- `TestMergeVersionVectorMaps` - Max-merge semantics
- `TestResolveConflictMaps` - Deterministic conflict resolution

✅ **Linting:** Clean (0 issues)  
✅ **Backward compatible:** Metadata fields are optional (omitempty)

## Example Usage

```go
// Configure store with coordinator ID
store.SetCoordinatorID("coord-1")

// Upload creates per-chunk metadata automatically
meta, err := store.PutObject(ctx, "bucket", "key", reader, ...)

// Metadata populated for each chunk:
// meta.ChunkMetadata["abc123..."] = {
//     Hash: "abc123...",
//     VersionVector: {"coord-1": 1},
//     Owners: ["coord-1"],
//     FirstSeen: <timestamp>,
//     LastModified: <timestamp>
// }
```

## Benefits

| Category | Improvement |
|----------|-------------|
| 🔀 Conflict Resolution | Chunk-level instead of file-level (finer granularity) |
| 📊 Causality Tracking | Version vectors enable distributed conflict detection |
| 🏗️ Foundation | Ready for Phase 4 (chunk-level replication protocol) |
| ✅ Compatibility | Backward compatible (metadata optional) |

## Architecture

```
Before (Phase 2):
File: video.mp4
├── Chunks: [ABC, DEF, GHI]
└── VersionVector: {"coord-1": 5} ← File level only

After (Phase 3):
File: video.mp4  
├── Chunks: [ABC, DEF, GHI]
├── VersionVector: {"coord-1": 5} ← File level
└── ChunkMetadata:
    ├── ABC: {VV: {"coord-1": 1}, Owners: ["coord-1"]} ← Per chunk
    ├── DEF: {VV: {"coord-1": 1}, Owners: ["coord-1"]}
    └── GHI: {VV: {"coord-1": 1}, Owners: ["coord-1"]}
```

## Next Steps (Phase 4)

Phase 4 will implement the chunk-level replication protocol:
- Use version vectors to detect conflicts
- Replicate individual chunks (not whole files)
- Merge chunk metadata using conflict resolution functions
- Enable resume capability (replicate only missing chunks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)