### PR TITLE
Add explicit system bucket protection to UpdateBucket API

### DIFF
--- a/internal/coord/admin.go
+++ b/internal/coord/admin.go
@@ -1951,6 +1951,12 @@ func (s *Server) handleUpdateBucket(w http.ResponseWriter, r *http.Request, buck
 		return
 	}
 
+	// Block system bucket modifications (check before auth to match S3 proxy pattern)
+	if bucket == auth.SystemBucket {
+		s.jsonError(w, "cannot modify system bucket", http.StatusForbidden)
+		return
+	}
+
 	// Check admin permission (bucket_scope=* or admin role)
 	userID := s.getRequestOwner(r)
 	if userID == "" {

--- a/internal/coord/admin_test.go
+++ b/internal/coord/admin_test.go
@@ -460,6 +460,25 @@ func TestS3Proxy_DeleteObject_SystemBucketForbidden(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 }
 
+func TestUpdateBucket_SystemBucketForbidden(t *testing.T) {
+	srv := newTestServerWithS3AndBucket(t)
+
+	// Attempt to update system bucket replication factor
+	reqBody := `{"replication_factor": 1}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/s3/buckets/"+auth.SystemBucket, bytes.NewReader([]byte(reqBody)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.adminMux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	// Verify error message
+	var resp proto.ErrorResponse
+	err := json.NewDecoder(rec.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Contains(t, resp.Message, "cannot modify system bucket")
+}
+
 func TestS3Proxy_HeadObject(t *testing.T) {
 	srv := newTestServerWithS3AndBucket(t)
 


### PR DESCRIPTION
## Summary

- Add explicit guard clause to prevent modifications to the `_tunnelmesh` system bucket
- System bucket is protected at the handler level before authentication checks
- Follows the same pattern as `handleS3PutObject` for consistency

## Changes

- **internal/coord/admin.go**: Add system bucket check in `handleUpdateBucket` before authentication validation
- **internal/coord/admin_test.go**: Add `TestUpdateBucket_SystemBucketForbidden` to verify 403 response

## Why

The system bucket is hardcoded to replication factor 3 for maximum durability of coordinator state (auth, roles, groups, DNS records, filter rules, stats). Admins should not be able to modify this configuration through the API.

## Test Plan

- ✅ All tests pass (`make test`)
- ✅ Linter passes (`golangci-lint run`)  
- ✅ New test verifies system bucket cannot be modified via PATCH endpoint
- ✅ Returns 403 with clear error message: "cannot modify system bucket"

🤖 Generated with [Claude Code](https://claude.com/claude-code)