### PR TITLE
Fix Docker peer names, Grafana datasource UIDs, and sparkline links

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -118,12 +118,12 @@ services:
       retries: 5
       start_period: 3s
 
-  client:
+  alice:
     build:
       context: ..
       dockerfile: docker/Dockerfile
-    deploy:
-      replicas: 5
+    hostname: alice
+    container_name: tunnelmesh-alice
     entrypoint: ["/bin/bash", "/scripts/client-entrypoint.sh"]
     volumes:
       - ./config/peer.yaml.template:/etc/tunnelmesh/peer.yaml.template:ro
@@ -138,6 +138,115 @@ services:
     networks:
       - mesh-control
     environment:
+      - NODE_NAME=alice
+      - SERVER_URL=http://coordinator-1:8080
+      - AUTH_TOKEN=${TUNNELMESH_TOKEN}
+      - TUNNELMESH_ALLOW_HTTP=true
+      - PING_INTERVAL=2
+      - DISCOVERY_INTERVAL=20
+
+  bob:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    hostname: bob
+    container_name: tunnelmesh-bob
+    entrypoint: ["/bin/bash", "/scripts/client-entrypoint.sh"]
+    volumes:
+      - ./config/peer.yaml.template:/etc/tunnelmesh/peer.yaml.template:ro
+      - ./scripts/client-entrypoint.sh:/scripts/client-entrypoint.sh:ro
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    depends_on:
+      coord-1:
+        condition: service_started
+    networks:
+      - mesh-control
+    environment:
+      - NODE_NAME=bob
+      - SERVER_URL=http://coordinator-1:8080
+      - AUTH_TOKEN=${TUNNELMESH_TOKEN}
+      - TUNNELMESH_ALLOW_HTTP=true
+      - PING_INTERVAL=2
+      - DISCOVERY_INTERVAL=20
+
+  charlie:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    hostname: charlie
+    container_name: tunnelmesh-charlie
+    entrypoint: ["/bin/bash", "/scripts/client-entrypoint.sh"]
+    volumes:
+      - ./config/peer.yaml.template:/etc/tunnelmesh/peer.yaml.template:ro
+      - ./scripts/client-entrypoint.sh:/scripts/client-entrypoint.sh:ro
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    depends_on:
+      coord-1:
+        condition: service_started
+    networks:
+      - mesh-control
+    environment:
+      - NODE_NAME=charlie
+      - SERVER_URL=http://coordinator-1:8080
+      - AUTH_TOKEN=${TUNNELMESH_TOKEN}
+      - TUNNELMESH_ALLOW_HTTP=true
+      - PING_INTERVAL=2
+      - DISCOVERY_INTERVAL=20
+
+  diana:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    hostname: diana
+    container_name: tunnelmesh-diana
+    entrypoint: ["/bin/bash", "/scripts/client-entrypoint.sh"]
+    volumes:
+      - ./config/peer.yaml.template:/etc/tunnelmesh/peer.yaml.template:ro
+      - ./scripts/client-entrypoint.sh:/scripts/client-entrypoint.sh:ro
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    depends_on:
+      coord-1:
+        condition: service_started
+    networks:
+      - mesh-control
+    environment:
+      - NODE_NAME=diana
+      - SERVER_URL=http://coordinator-1:8080
+      - AUTH_TOKEN=${TUNNELMESH_TOKEN}
+      - TUNNELMESH_ALLOW_HTTP=true
+      - PING_INTERVAL=2
+      - DISCOVERY_INTERVAL=20
+
+  eve:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    hostname: eve
+    container_name: tunnelmesh-eve
+    entrypoint: ["/bin/bash", "/scripts/client-entrypoint.sh"]
+    volumes:
+      - ./config/peer.yaml.template:/etc/tunnelmesh/peer.yaml.template:ro
+      - ./scripts/client-entrypoint.sh:/scripts/client-entrypoint.sh:ro
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    depends_on:
+      coord-1:
+        condition: service_started
+    networks:
+      - mesh-control
+    environment:
+      - NODE_NAME=eve
       - SERVER_URL=http://coordinator-1:8080
       - AUTH_TOKEN=${TUNNELMESH_TOKEN}
       - TUNNELMESH_ALLOW_HTTP=true

--- a/docker/scripts/client-entrypoint.sh
+++ b/docker/scripts/client-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-# Generate unique node name from hostname
-NODE_NAME="node-$(hostname)"
+# Use NODE_NAME env var if set, otherwise generate from hostname
+NODE_NAME="${NODE_NAME:-node-$(hostname)}"
 export NODE_NAME
 
 # Random first names for user registration

--- a/internal/coord/web/css/style.css
+++ b/internal/coord/web/css/style.css
@@ -425,6 +425,22 @@ main {
     stroke: var(--color-accent-green);
 }
 
+.sparkline-link {
+    text-decoration: none;
+    color: inherit;
+    cursor: pointer;
+    display: inline-block;
+}
+
+.sparkline-link > * {
+    display: inline-block;
+    vertical-align: middle;
+}
+
+.sparkline-link:hover {
+    background: var(--color-card-hover-bg);
+}
+
 .rate-values {
     display: inline-block;
     font-size: 0.75rem;

--- a/internal/coord/web/js/app.js
+++ b/internal/coord/web/js/app.js
@@ -512,18 +512,22 @@ function renderPeersTable() {
             <td><code>${peer.mesh_ip}</code>${tunnelSuffix}</td>
             <td>${formatLatency(peer.coordinator_rtt_ms)}</td>
             <td class="sparkline-cell">
+                <a class="sparkline-link" href="/grafana/d/tunnelmesh-overview/tunnelmesh-overview?orgId=1&viewPanel=7" target="_blank">
                 ${createSparklineSVG(history.throughputTx, history.throughputRx)}
                 <div class="rate-values">
                     <span class="tx">${formatBytes(peer.bytes_sent_rate)}/s</span>
                     <span class="rx">${formatBytes(peer.bytes_received_rate)}/s</span>
                 </div>
+                </a>
             </td>
             <td class="sparkline-cell">
+                <a class="sparkline-link" href="/grafana/d/tunnelmesh-overview/tunnelmesh-overview?orgId=1&viewPanel=8" target="_blank">
                 ${createSparklineSVG(history.packetsTx, history.packetsRx)}
                 <div class="rate-values">
                     <span class="tx">${formatRate(peer.packets_sent_rate)}</span>
                     <span class="rx">${formatRate(peer.packets_received_rate)}</span>
                 </div>
+                </a>
             </td>
             <td><code>${escapeHtml(peer.version || '-')}</code></td>
             <td><span class="status-badge ${peer.online ? 'online' : 'offline'}">${peer.online ? 'Online' : 'Offline'}</span></td>

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -3,6 +3,7 @@ apiVersion: 1
 datasources:
   - name: Prometheus
     type: prometheus
+    uid: PBFA97CFB590B2093
     access: proxy
     # Prometheus serves at /prometheus/ path (--web.route-prefix)
     url: http://localhost:9090/prometheus
@@ -11,6 +12,7 @@ datasources:
 
   - name: Loki
     type: loki
+    uid: P8E80F9AEF21F6940
     access: proxy
     url: http://localhost:3100
     isDefault: false


### PR DESCRIPTION
## Summary

- **Docker Compose friendly peer names**: Replace the single replicated `client` service with 5 individually named services (alice, bob, charlie, diana, eve) so peers show readable names in the dashboard instead of `node-abc123def`
- **Grafana datasource UID mismatch**: Add `uid` fields to the Grafana datasource provisioning config to match the UIDs hardcoded in the dashboard JSON, fixing all S3 panels showing "No data"
- **Sparkline click-to-Grafana**: Wrap sparkline cells in the peers table with links to the corresponding Grafana panels (throughput -> panel 7, packet rate -> panel 8)

## Test plan

- [ ] `make test` passes
- [ ] `golangci-lint run` clean
- [ ] `npx stylelint` and `npx biome check` clean
- [ ] `docker compose down -v && docker compose up -d` shows 5 named peers (alice, bob, charlie, diana, eve)
- [ ] Grafana S3 panels at `/grafana/d/tunnelmesh-overview/` show data
- [ ] Clicking throughput sparkline opens Grafana panel 7 in new tab
- [ ] Clicking packet rate sparkline opens Grafana panel 8 in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)