### PR TITLE
Fix Prometheus coordinator scraping timeout

### DIFF
--- a/internal/promsd/generator_test.go
+++ b/internal/promsd/generator_test.go
@@ -462,7 +462,6 @@ func TestHTTPFetcher_ConnectionError(t *testing.T) {
 
 func TestCoordinatorsToTargets(t *testing.T) {
 	now := time.Now()
-	threshold := 2 * time.Minute
 
 	tests := []struct {
 		name     string
@@ -490,11 +489,11 @@ func TestCoordinatorsToTargets(t *testing.T) {
 			expected: 1,
 		},
 		{
-			name: "offline coordinator filtered",
+			name: "offline coordinator still included",
 			peers: []Peer{
 				{Name: "coord-1", MeshIP: "10.42.0.1", LastSeen: now.Add(-5 * time.Minute), IsCoordinator: true},
 			},
-			expected: 0,
+			expected: 1,
 		},
 		{
 			name: "coordinator without mesh IP filtered",
@@ -507,7 +506,7 @@ func TestCoordinatorsToTargets(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			targets := CoordinatorsToTargets(tt.peers, threshold, now)
+			targets := CoordinatorsToTargets(tt.peers)
 			if len(targets) != tt.expected {
 				t.Errorf("expected %d targets, got %d", tt.expected, len(targets))
 			}
@@ -516,12 +515,11 @@ func TestCoordinatorsToTargets(t *testing.T) {
 }
 
 func TestCoordinatorsToTargets_TargetFormat(t *testing.T) {
-	now := time.Now()
 	peers := []Peer{
-		{Name: "coord-1", MeshIP: "10.42.0.42", LastSeen: now, IsCoordinator: true},
+		{Name: "coord-1", MeshIP: "10.42.0.42", IsCoordinator: true},
 	}
 
-	targets := CoordinatorsToTargets(peers, 2*time.Minute, now)
+	targets := CoordinatorsToTargets(peers)
 
 	if len(targets) != 1 {
 		t.Fatalf("expected 1 target, got %d", len(targets))


### PR DESCRIPTION
## Summary

- Replace hardcoded coordinator mesh IP (`10.85.0.1:443`) in Prometheus config with dynamic file-based service discovery
- Extend the SD generator to also output a `coordinators.json` targets file by filtering peers with the `is_coordinator` API flag (port 443)
- The `tunnelmesh-coordinator` scrape job now uses `file_sd_configs` like the peer job, resolving the `context deadline exceeded` error

## Test plan

- [ ] `make test` passes (20 promsd tests including 3 new coordinator tests)
- [ ] `golangci-lint run` clean
- [ ] Docker stack: SD generator outputs both `peers.json` and `coordinators.json`
- [ ] Grafana coordinator panels (S3, relay) show data

🤖 Generated with [Claude Code](https://claude.com/claude-code)