### PR TITLE
Fix s3bench: use coordinator URL directly for S3 API calls

### DIFF
--- a/cmd/tunnelmesh-s3bench/main.go
+++ b/cmd/tunnelmesh-s3bench/main.go
@@ -290,18 +290,17 @@ func runScenario(cmd *cobra.Command, args []string) error {
 		log.Info().
 			Str("peer_id", meshInfo.PeerID).
 			Str("mesh_ip", meshInfo.MeshIP).
-			Str("coord_mesh_ip", meshInfo.CoordMeshIP).
 			Bool("is_admin", meshInfo.IsAdmin).
 			Msg("Registration successful")
 
 		// Derive S3 credentials
 		log.Info().Str("access_key", creds.AccessKey).Msg("Derived S3 credentials")
 
-		// Create mesh client targeting coordinator's mesh IP
+		// Create mesh client targeting coordinator URL directly
 		log.Info().
-			Str("s3_endpoint", fmt.Sprintf("https://%s:443", meshInfo.CoordMeshIP)).
-			Msg("Creating shares on coordinator mesh IP")
-		meshClient = mesh.NewCoordinatorClient(meshInfo.CoordMeshIP, creds, insecureTLS)
+			Str("s3_endpoint", coordinatorURL).
+			Msg("Creating shares on coordinator")
+		meshClient = mesh.NewCoordinatorClient(coordinatorURL, creds, insecureTLS)
 
 		// Create shares for each department (coordinator auto-prefixes with peer name)
 		for _, dept := range st.Departments() {

--- a/internal/s3bench/mesh/coordinator_client.go
+++ b/internal/s3bench/mesh/coordinator_client.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/tunnelmesh/tunnelmesh/internal/coord/s3"
@@ -24,10 +25,10 @@ type CoordinatorClient struct {
 }
 
 // NewCoordinatorClient creates a new coordinator S3 API client.
-// meshIP should be the coordinator's mesh IP (e.g., "10.42.0.1").
-func NewCoordinatorClient(meshIP string, creds *Credentials, insecureSkipVerify bool) *CoordinatorClient {
+// baseURL should be the coordinator's URL (e.g., "http://localhost:8081").
+func NewCoordinatorClient(baseURL string, creds *Credentials, insecureSkipVerify bool) *CoordinatorClient {
 	return &CoordinatorClient{
-		baseURL:   fmt.Sprintf("https://%s:443", meshIP),
+		baseURL:   strings.TrimRight(baseURL, "/"),
 		accessKey: creds.AccessKey,
 		secretKey: creds.SecretKey,
 		httpClient: &http.Client{

--- a/internal/s3bench/mesh/registration.go
+++ b/internal/s3bench/mesh/registration.go
@@ -14,11 +14,10 @@ import (
 
 // MeshInfo contains mesh connectivity information returned by registration.
 type MeshInfo struct {
-	MeshIP      string // This peer's assigned mesh IP
-	CoordMeshIP string // Coordinator's mesh IP (for S3 API access)
-	PeerID      string // Peer ID for RBAC
-	PeerName    string // Assigned peer name (may differ if renamed)
-	IsAdmin     bool   // Whether peer has admin access
+	MeshIP   string // This peer's assigned mesh IP
+	PeerID   string // Peer ID for RBAC
+	PeerName string // Assigned peer name (may differ if renamed)
+	IsAdmin  bool   // Whether peer has admin access
 }
 
 // RegisterWithCoordinator registers s3bench as a peer with the coordinator.
@@ -91,18 +90,11 @@ func RegisterWithCoordinator(ctx context.Context, coordinatorURL string, creds *
 		return nil, fmt.Errorf("decode registration response: %w", err)
 	}
 
-	// Extract mesh info - use first coordinator IP for S3 API access
-	var coordMeshIP string
-	if len(regResp.CoordMeshIPs) > 0 {
-		coordMeshIP = regResp.CoordMeshIPs[0]
-	}
-
 	meshInfo := &MeshInfo{
-		MeshIP:      regResp.MeshIP,
-		CoordMeshIP: coordMeshIP,
-		PeerID:      regResp.PeerID,
-		PeerName:    regResp.PeerName,
-		IsAdmin:     regResp.IsAdmin,
+		MeshIP:   regResp.MeshIP,
+		PeerID:   regResp.PeerID,
+		PeerName: regResp.PeerName,
+		IsAdmin:  regResp.IsAdmin,
 	}
 
 	return meshInfo, nil

--- a/internal/s3bench/mesh/registration_test.go
+++ b/internal/s3bench/mesh/registration_test.go
@@ -158,13 +158,6 @@ func TestRegisterWithCoordinator(t *testing.T) {
 				if meshInfo.MeshIP != tt.serverResponse.MeshIP {
 					t.Errorf("Expected MeshIP=%s, got %s", tt.serverResponse.MeshIP, meshInfo.MeshIP)
 				}
-				expectedCoordIP := ""
-				if len(tt.serverResponse.CoordMeshIPs) > 0 {
-					expectedCoordIP = tt.serverResponse.CoordMeshIPs[0]
-				}
-				if meshInfo.CoordMeshIP != expectedCoordIP {
-					t.Errorf("Expected CoordMeshIP=%s, got %s", expectedCoordIP, meshInfo.CoordMeshIP)
-				}
 				if meshInfo.PeerID != tt.serverResponse.PeerID {
 					t.Errorf("Expected PeerID=%s, got %s", tt.serverResponse.PeerID, meshInfo.PeerID)
 				}


### PR DESCRIPTION
## Summary

- s3bench doesn't join the mesh (no TUN, no tunnels), so it can never reach mesh IPs
- Changed `NewCoordinatorClient` to accept a full base URL instead of a mesh IP
- Pass `--coordinator` URL directly to the S3 client instead of extracting `CoordMeshIPs[0]` from registration response (which may be empty)
- Removed unused `CoordMeshIP` field from `MeshInfo` struct

## Test plan

- [x] `make test` — all tests pass
- [x] `golangci-lint run` — no issues
- [ ] Manual: `tunnelmesh-s3bench run alien_invasion --coordinator http://localhost:8081 --auth-token "..." --time-scale 2000 --json results.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)