### PR TITLE
Fix s3bench: use admin mux for S3/share operations

### DIFF
--- a/cmd/tunnelmesh-s3bench/main.go
+++ b/cmd/tunnelmesh-s3bench/main.go
@@ -112,7 +112,7 @@ func init() {
 	// Mesh integration flags
 	runCmd.Flags().StringVar(&coordinatorURL, "coordinator", "", "Coordinator URL (enables mesh mode, e.g., https://coordinator.example.com:8443)")
 	runCmd.Flags().StringVar(&sshKeyPath, "ssh-key", "", "SSH private key path (default: ~/.tunnelmesh/s3bench_key)")
-	runCmd.Flags().BoolVar(&insecureTLS, "insecure-tls", false, "Skip TLS certificate verification (only use with self-signed certs for testing)")
+	runCmd.Flags().BoolVar(&insecureTLS, "insecure-tls", true, "Skip TLS certificate verification (admin mux uses mesh CA)")
 	runCmd.Flags().StringVar(&authToken, "auth-token", "", "Coordinator auth token (for protected coordinators)")
 }
 
@@ -296,11 +296,16 @@ func runScenario(cmd *cobra.Command, args []string) error {
 		// Derive S3 credentials
 		log.Info().Str("access_key", creds.AccessKey).Msg("Derived S3 credentials")
 
-		// Create mesh client targeting coordinator URL directly
+		// Construct admin mux URL from coordinator mesh IP
+		adminURL := coordinatorURL // fallback to coordinator URL
+		if len(meshInfo.CoordMeshIPs) > 0 {
+			adminURL = fmt.Sprintf("https://%s", meshInfo.CoordMeshIPs[0])
+		}
+
 		log.Info().
-			Str("s3_endpoint", coordinatorURL).
-			Msg("Creating shares on coordinator")
-		meshClient = mesh.NewCoordinatorClient(coordinatorURL, creds, insecureTLS)
+			Str("s3_endpoint", adminURL).
+			Msg("Creating shares on coordinator admin mux")
+		meshClient = mesh.NewCoordinatorClient(adminURL, creds, insecureTLS)
 
 		// Create shares for each department (coordinator auto-prefixes with peer name)
 		for _, dept := range st.Departments() {

--- a/internal/s3bench/mesh/registration.go
+++ b/internal/s3bench/mesh/registration.go
@@ -14,10 +14,11 @@ import (
 
 // MeshInfo contains mesh connectivity information returned by registration.
 type MeshInfo struct {
-	MeshIP   string // This peer's assigned mesh IP
-	PeerID   string // Peer ID for RBAC
-	PeerName string // Assigned peer name (may differ if renamed)
-	IsAdmin  bool   // Whether peer has admin access
+	MeshIP       string   // This peer's assigned mesh IP
+	PeerID       string   // Peer ID for RBAC
+	PeerName     string   // Assigned peer name (may differ if renamed)
+	IsAdmin      bool     // Whether peer has admin access
+	CoordMeshIPs []string // Coordinator mesh IPs for admin mux access
 }
 
 // RegisterWithCoordinator registers s3bench as a peer with the coordinator.
@@ -91,10 +92,11 @@ func RegisterWithCoordinator(ctx context.Context, coordinatorURL string, creds *
 	}
 
 	meshInfo := &MeshInfo{
-		MeshIP:   regResp.MeshIP,
-		PeerID:   regResp.PeerID,
-		PeerName: regResp.PeerName,
-		IsAdmin:  regResp.IsAdmin,
+		MeshIP:       regResp.MeshIP,
+		PeerID:       regResp.PeerID,
+		PeerName:     regResp.PeerName,
+		IsAdmin:      regResp.IsAdmin,
+		CoordMeshIPs: regResp.CoordMeshIPs,
 	}
 
 	return meshInfo, nil


### PR DESCRIPTION
## Summary

- After registration on the public mux, construct admin mux URL from `CoordMeshIPs` in the registration response
- Use admin mux URL (`https://{coordMeshIP}`) for all S3/share operations (`/api/shares`, `/api/s3/*`)
- Default `--insecure-tls` to `true` since the admin mux uses the mesh CA (self-signed)

Fixes 404s on share creation and S3 operations when `--coordinator` points to the public mux.

## Test plan

- [x] `make test` passes
- [x] `golangci-lint run` clean
- [ ] Manual: run s3bench with `--coordinator http://localhost:8081` against a coordinator with mesh IPs, verify shares and S3 uploads succeed on the admin mux

🤖 Generated with [Claude Code](https://claude.com/claude-code)