### PR TITLE
Fix s3bench hanging due to S3 metrics lock contention

### DIFF
--- a/internal/coord/s3/store.go
+++ b/internal/coord/s3/store.go
@@ -2695,8 +2695,10 @@ func (s *Store) GetCASStats() CASStats {
 		return stats
 	}
 
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	// No lock needed: s.dataDir is immutable after construction, all writes
+	// use atomic temp+rename (syncedWriteFile), and these are approximate
+	// gauge metrics refreshed every 60s where brief races are acceptable.
+	// This avoids RLock contention that starves concurrent PutObject writers.
 
 	// Count chunks and their sizes
 	chunksDir := filepath.Join(s.dataDir, "chunks")

--- a/internal/s3bench/simulator/simulator.go
+++ b/internal/s3bench/simulator/simulator.go
@@ -89,6 +89,7 @@ type Simulator struct {
 	sharePrefix string                  // Peer name prefix for share bucket names
 
 	// Execution state
+	generated bool
 	startTime time.Time
 	tasks     []WorkloadTask
 	attempts  map[string][]AdversaryAttempt // Map character ID to attempts
@@ -212,7 +213,12 @@ func (s *Simulator) shareBucketName(shareName string) string {
 }
 
 // GenerateScenario generates all tasks, attempts, and workflows for the scenario.
+// It is idempotent: subsequent calls after the first are no-ops.
 func (s *Simulator) GenerateScenario(ctx context.Context) error {
+	if s.generated {
+		return nil
+	}
+
 	var err error
 
 	// Generate workload tasks
@@ -253,6 +259,7 @@ func (s *Simulator) GenerateScenario(ctx context.Context) error {
 		s.metrics.WorkflowTestsRun = len(s.workflows)
 	}
 
+	s.generated = true
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- **Remove RLock from `GetCASStats()`** — the 60-second metrics refresh was acquiring `s.mu.RLock()` and doing full filesystem walks, starving concurrent `PutObject()` writers that need `s.mu.Lock()`. Lock is unnecessary since `dataDir` is immutable and all writes use atomic temp+rename.
- **Merge `updateCASMetrics()` + `updateStorageMetrics()` into `updateS3Metrics()`** — eliminates the duplicate `GetCASStats()` call that doubled filesystem scanning on every refresh cycle.
- **Make `GenerateScenario()` idempotent** — `Run()` calls `GenerateScenario()` internally, so calling it before `Run()` (as `runIteration()` does in accordion mode) caused double workflow generation.

## Test plan

- [x] `make test` — all tests pass
- [x] `golangci-lint run` — 0 issues
- [ ] Manual: `tunnelmesh-s3bench run alien_invasion --coordinator <url> --accordion --time-scale 4320` completes iteration 1 in ~1 minute without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)