### PR TITLE
Fix S3 GC metrics, dedup storage reporting, and GC stats

### DIFF
--- a/internal/coord/admin_test.go
+++ b/internal/coord/admin_test.go
@@ -283,6 +283,12 @@ func TestS3Proxy_ListBuckets(t *testing.T) {
 	}
 	require.NotNil(t, testBucket)
 	assert.True(t, testBucket.Writable)
+
+	// Verify dedup storage info is present
+	require.NotNil(t, resp.Storage)
+	assert.GreaterOrEqual(t, resp.Storage.PhysicalBytes, int64(0))
+	assert.GreaterOrEqual(t, resp.Storage.LogicalBytes, int64(0))
+	assert.GreaterOrEqual(t, resp.Storage.DedupRatio, 1.0)
 }
 
 func TestS3Proxy_ListBuckets_SystemBucketReadOnly(t *testing.T) {
@@ -1437,6 +1443,7 @@ func TestS3GC_PurgeAllTombstoned(t *testing.T) {
 	assert.Contains(t, result, "versions_pruned")
 	assert.Contains(t, result, "chunks_deleted")
 	assert.Contains(t, result, "bytes_reclaimed")
+	assert.Contains(t, result, "duration_seconds")
 }
 
 func TestS3GC_WithoutPurgeAll(t *testing.T) {

--- a/internal/coord/s3/metrics.go
+++ b/internal/coord/s3/metrics.go
@@ -97,7 +97,7 @@ func InitS3Metrics(registry prometheus.Registerer) *S3Metrics {
 
 			StorageBytes: promauto.With(registry).NewGauge(prometheus.GaugeOpts{
 				Name: "tunnelmesh_s3_storage_bytes",
-				Help: "Total bytes stored in S3",
+				Help: "Total physical bytes stored in S3 (after deduplication)",
 			}),
 
 			QuotaBytes: promauto.With(registry).NewGauge(prometheus.GaugeOpts{

--- a/internal/coord/web/js/s3explorer.js
+++ b/internal/coord/web/js/s3explorer.js
@@ -808,6 +808,7 @@
             // Store quota info in state
             state.quota = data.quota || null;
             state.volume = data.volume || null;
+            state.storage = data.storage || null;
             return data.buckets || [];
         } catch (err) {
             console.error('Failed to fetch buckets:', err);
@@ -986,7 +987,7 @@
             else return;
         }
         bar.style.display = 'block';
-        bar.innerHTML =
+        let html =
             `<div style="display:flex;align-items:center;gap:10px;font-size:12px">` +
             `<span>Volume</span>` +
             `<div style="flex:1;height:8px;background:var(--bg-tertiary, #2a2a3e);position:relative">` +
@@ -994,6 +995,19 @@
             `<span>${pct}% used</span>` +
             `<span style="color:var(--text-secondary, #888)">${formatBytes(v.used_bytes)} / ${formatBytes(v.total_bytes)} (${formatBytes(v.available_bytes)} free)</span>` +
             `</div>`;
+        // Show dedup storage info when available
+        if (state.storage && state.storage.physical_bytes > 0) {
+            const s = state.storage;
+            const ratio = s.dedup_ratio.toFixed(1);
+            html +=
+                `<div style="font-size:11px;color:var(--text-secondary, #888);margin-top:4px">` +
+                `Storage: ${formatBytes(s.physical_bytes)} on disk` +
+                (s.logical_bytes !== s.physical_bytes
+                    ? ` (${formatBytes(s.logical_bytes)} logical, ${ratio}x dedup)`
+                    : '') +
+                `</div>`;
+        }
+        bar.innerHTML = html;
     }
 
     /* istanbul ignore next */


### PR DESCRIPTION
## Summary

- **Manual GC metrics**: `POST /api/s3/gc` now records Prometheus metrics (`RecordGCRun`), refreshes storage gauges, and logs full stats — making manual GC runs visible in dashboards
- **GC serialization**: Periodic GC uses `gcMu.TryLock()` to skip cycles when manual GC is running, preventing concurrent GC runs
- **Always-log GC**: All GC runs are now logged (Info when work was done, Debug for no-ops) with duration field
- **Physical storage metric**: `tunnelmesh_s3_storage_bytes` now reports physical chunk bytes (post-dedup) instead of logical bucket size sum, so dedup savings are reflected in the headline metric
- **Dedup stats in API**: Bucket list response includes `storage.physical_bytes`, `storage.logical_bytes`, `storage.dedup_ratio`
- **Dedup stats in UI**: S3 explorer shows dedup info below the volume bar (e.g., "Storage: 1.2 GB on disk (3.6 GB logical, 3.0x dedup)")

## Test plan

- [x] `make test` passes
- [x] `golangci-lint run` clean
- [ ] Upload duplicate files, confirm `tunnelmesh_s3_storage_bytes` stays flat while `tunnelmesh_s3_logical_bytes` grows
- [ ] Trigger manual GC via `POST /api/s3/gc`, confirm `tunnelmesh_s3_gc_runs_total` increments
- [ ] Check logs: GC runs visible at Info (work done) or Debug (no-ops)
- [ ] Bucket list API includes `storage` object with dedup stats
- [ ] Web UI shows dedup info line below volume bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)