### PR TITLE
Fix S3 delete purge, contention data loss, and s3bench HTTPS forcing

### DIFF
--- a/cmd/tunnelmesh-s3bench/main.go
+++ b/cmd/tunnelmesh-s3bench/main.go
@@ -320,9 +320,9 @@ func runScenario(cmd *cobra.Command, args []string) error {
 		log.Info().Str("access_key", creds.AccessKey).Msg("Derived S3 credentials")
 
 		// s3bench is a lightweight peer with no TUN interface — use the
-		// coordinator URL directly.  Replace scheme with https since the
-		// admin mux requires TLS.
-		adminURL := strings.Replace(coordinatorURL, "http://", "https://", 1)
+		// coordinator URL directly. The admin mux supports both HTTP and HTTPS;
+		// the user provides the correct scheme via --coordinator.
+		adminURL := coordinatorURL
 
 		log.Info().
 			Str("s3_endpoint", adminURL).

--- a/internal/coord/admin_s3_listing_test.go
+++ b/internal/coord/admin_s3_listing_test.go
@@ -2,8 +2,10 @@ package coord
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUpsertObjectList_NewKey(t *testing.T) {
@@ -39,4 +41,83 @@ func TestListingIndexEqual_OneNil(t *testing.T) {
 	idx := &listingIndex{Buckets: make(map[string]*bucketListing)}
 	assert.False(t, listingIndexEqual(nil, idx))
 	assert.False(t, listingIndexEqual(idx, nil))
+}
+
+func TestListingIndexEqual_IgnoresSeq(t *testing.T) {
+	a := &listingIndex{
+		Buckets: map[string]*bucketListing{
+			"b": {Objects: []S3ObjectInfo{{Key: "k", Size: 1, LastModified: "t1"}}},
+		},
+		Seq: 5,
+	}
+	b := &listingIndex{
+		Buckets: map[string]*bucketListing{
+			"b": {Objects: []S3ObjectInfo{{Key: "k", Size: 1, LastModified: "t1"}}},
+		},
+		Seq: 99,
+	}
+	assert.True(t, listingIndexEqual(a, b), "Seq should be ignored in equality comparison")
+}
+
+func TestUpdateListingIndex_IncrementsSeq(t *testing.T) {
+	srv := newTestServerWithListingIndex(t)
+
+	info := S3ObjectInfo{Key: "a.txt", Size: 10, LastModified: "2024-01-01T00:00:00Z"}
+	srv.updateListingIndex("bkt", "a.txt", &info, "put")
+
+	idx := srv.localListingIndex.Load()
+	require.NotNil(t, idx)
+	assert.Equal(t, uint64(1), idx.Seq)
+
+	// Second update should increment again
+	info2 := S3ObjectInfo{Key: "b.txt", Size: 20, LastModified: "2024-01-02T00:00:00Z"}
+	srv.updateListingIndex("bkt", "b.txt", &info2, "put")
+
+	idx2 := srv.localListingIndex.Load()
+	assert.Equal(t, uint64(2), idx2.Seq)
+}
+
+func TestReconcileLocalIndex_SkipsWhenSeqAdvanced(t *testing.T) {
+	srv := newTestServerWithListingIndex(t)
+
+	// Pre-populate listing index (Seq=1)
+	info := S3ObjectInfo{Key: "file.txt", Size: 100, LastModified: "2024-01-01T00:00:00Z"}
+	srv.updateListingIndex("test-bucket", "file.txt", &info, "put")
+
+	before := srv.localListingIndex.Load()
+	require.NotNil(t, before)
+	require.Equal(t, uint64(1), before.Seq)
+
+	// Run reconcile in a goroutine so we can do an incremental update while
+	// it scans the filesystem (ListBuckets → ListObjects → ListRecycledObjects).
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.reconcileLocalIndex(t.Context())
+	}()
+
+	// Give reconcile time to capture preSeq and start the filesystem scan.
+	time.Sleep(20 * time.Millisecond)
+
+	// Incremental update bumps Seq from 1 → 2 while reconcile is mid-scan.
+	info2 := S3ObjectInfo{Key: "concurrent.txt", Size: 50, LastModified: "2024-01-02T00:00:00Z"}
+	srv.updateListingIndex("test-bucket", "concurrent.txt", &info2, "put")
+
+	<-done
+
+	after := srv.localListingIndex.Load()
+	require.NotNil(t, after)
+
+	// The concurrent update must be preserved — reconcile either skipped
+	// (because Seq advanced) or CAS failed (because pointer changed).
+	assert.Equal(t, uint64(2), after.Seq)
+	bl := after.Buckets["test-bucket"]
+	require.NotNil(t, bl)
+	found := false
+	for _, obj := range bl.Objects {
+		if obj.Key == "concurrent.txt" {
+			found = true
+		}
+	}
+	assert.True(t, found, "concurrent incremental update should be preserved")
 }


### PR DESCRIPTION
## Summary

- **Fix forwarded DELETE purging documents**: `updatePeerListingsAfterForward` now adds deleted objects to the peer recycled cache with a `DeletedAt` timestamp, instead of silently dropping them
- **Fix contention-induced data loss**: Refactored `PutObject` and `putObjectWithErasureCoding` to hold the global lock only during brief metadata I/O (microseconds), not during the entire streaming/encoding phase (potentially seconds). Added a monotonic `Seq` counter to `listingIndex` so `reconcileLocalIndex` skips when incremental updates happened during its filesystem scan
- **Fix s3bench HTTPS forcing**: Removed the `strings.Replace(url, "http://", "https://", 1)` that broke connections to admin muxes running without TLS

## Test plan

- [x] New test: forwarded DELETE places object in recycled list with DeletedAt
- [x] New test: forwarded DELETE of non-existent key leaves recycled empty  
- [x] New test: `listingIndexEqual` ignores Seq field
- [x] New test: `updateListingIndex` increments Seq monotonically
- [x] New test: reconcile skips when Seq advances during scan
- [x] New test: concurrent PutObject + ListObjects verifies reads aren't blocked
- [x] Existing concurrent PutObject tests pass
- [x] `make test` — all tests pass
- [x] `golangci-lint run` — 0 issues
- [x] Race detector — no data races on new/modified tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)