### PR TITLE
Fix s3bench to use coordinator mesh IP for admin API

### DIFF
--- a/cmd/tunnelmesh-s3bench/main.go
+++ b/cmd/tunnelmesh-s3bench/main.go
@@ -319,10 +319,13 @@ func runScenario(cmd *cobra.Command, args []string) error {
 		// Derive S3 credentials
 		log.Info().Str("access_key", creds.AccessKey).Msg("Derived S3 credentials")
 
-		// s3bench is a lightweight peer with no TUN interface — use the
-		// coordinator URL directly. The admin mux supports both HTTP and HTTPS;
-		// the user provides the correct scheme via --coordinator.
-		adminURL := coordinatorURL
+		// Admin routes (/api/shares, /api/s3/*) are only served on the admin
+		// mux bound to mesh_ip:443, not the public server. Use the coordinator's
+		// mesh IP from the registration response.
+		if len(meshInfo.CoordMeshIPs) == 0 {
+			return fmt.Errorf("no coordinator mesh IPs in registration response")
+		}
+		adminURL := "https://" + meshInfo.CoordMeshIPs[0]
 
 		log.Info().
 			Str("s3_endpoint", adminURL).


### PR DESCRIPTION
## Summary

- s3bench was using the public coordinator URL for admin API requests (`/api/shares`, `/api/s3/*`), which returned 404 because those routes are only served on the admin mux (`mesh_ip:443`)
- Now constructs the admin URL from `meshInfo.CoordMeshIPs[0]` returned during peer registration, which correctly targets the admin mux

## Test plan

- [ ] `go build ./cmd/tunnelmesh-s3bench/` compiles cleanly
- [ ] `make test` passes
- [ ] Run s3bench in mesh mode: `tunnelmesh-s3bench run alien_invasion --coordinator http://localhost:8081 --auth-token "..." --time-scale 2000` — shares and S3 operations succeed (no 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)