### PR TITLE
Fix forwarded S3 entries disappearing after loadPeerIndexes

### DIFF
--- a/internal/coord/admin_s3.go
+++ b/internal/coord/admin_s3.go
@@ -29,6 +29,7 @@ type S3ObjectInfo struct {
 	DeletedAt    string `json:"deleted_at,omitempty"` // When the object was deleted (recycled)
 	ContentType  string `json:"content_type,omitempty"`
 	IsPrefix     bool   `json:"is_prefix,omitempty"` // True for "folder" prefixes
+	Forwarded    bool   `json:"-"`                   // In-memory: survives loadPeerIndexes until remote persists
 }
 
 // S3BucketInfo represents an S3 bucket for the explorer API.

--- a/internal/coord/admin_s3_replication.go
+++ b/internal/coord/admin_s3_replication.go
@@ -80,6 +80,7 @@ func (s *Server) updatePeerListingsAfterForward(bucket, key string, r *http.Requ
 				Size:         r.ContentLength,
 				LastModified: time.Now().UTC().Format(time.RFC3339),
 				ContentType:  r.Header.Get("Content-Type"),
+				Forwarded:    true,
 			}
 			if info.ContentType == "" {
 				info.ContentType = "application/octet-stream"
@@ -95,6 +96,7 @@ func (s *Server) updatePeerListingsAfterForward(bucket, key string, r *http.Requ
 			if removed != nil {
 				recycled := *removed
 				recycled.DeletedAt = time.Now().UTC().Format(time.RFC3339)
+				recycled.Forwarded = true
 				newPL.Recycled[bucket] = append(newPL.Recycled[bucket], recycled)
 			}
 		}


### PR DESCRIPTION
## Summary

- In multi-coordinator setups, forwarded S3 writes inject entries into `peerListings` for immediate visibility. The `loadPeerIndexes` timer (10s) unconditionally replaced `peerListings` with system store data, causing forwarded entries to vanish before the remote peer persisted.
- Adds an in-memory `Forwarded` flag (`json:"-"`) to `S3ObjectInfo`, tags entries from `updatePeerListingsAfterForward`, and preserves them across `loadPeerIndexes` refreshes until system store data supersedes them.

## Test plan

- [x] Existing `TestUpdatePeerListingsAfterForward_Put` updated to assert `Forwarded == true`
- [x] Existing `TestUpdatePeerListingsAfterForward_Delete` updated to assert `Forwarded == true` on recycled entry
- [x] New `TestLoadPeerIndexes_PreservesForwardedEntries` — forwarded entry survives when system store has no data
- [x] New `TestLoadPeerIndexes_SupersedesForwardedEntry` — system store entry replaces forwarded entry once persisted
- [x] `make test` passes
- [x] `golangci-lint run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)