### PR TITLE
perf(s3): stream EC read path to eliminate O(fileSize) output buffers

### DIFF
--- a/internal/coord/s3/erasure_encoder.go
+++ b/internal/coord/s3/erasure_encoder.go
@@ -2,36 +2,37 @@ package s3
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/klauspost/reedsolomon"
 )
 
-// ReconstructBlockwise reconstructs the original file from partial shards
-// encoded by the streaming block method. shards[i] is nil if the shard is
-// unavailable. Each non-nil shard contains concatenated fixed-size pieces:
-// piece for block 0, piece for block 1, …, piece for block N-1.
+// ReconstructBlockwiseWriter reconstructs the original file from partial shards
+// and streams it block-by-block to w. Memory: O(streamBlockSize) constant
+// regardless of file size (one RS stripe processed at a time).
+//
+// shards[i] is nil if the shard is unavailable. Each non-nil shard contains
+// concatenated fixed-size pieces: piece for block 0, piece for block 1, …, block N-1.
 //
 // streamBlockSize is the RS stripe size (e.g. 4 MB for RS(4,2));
-// pieceSize = streamBlockSize / k. originalSize is the true file byte count
-// used to trim RS zero-padding from the last block.
+// pieceSize = streamBlockSize / k. originalSize trims RS zero-padding from the last block.
 //
-// Memory: O(fileSize) — assembles all shard buffers before block-wise RS
-// decode. Streaming block-by-block reconstruction is future work.
-func ReconstructBlockwise(shards [][]byte, k, m int, streamBlockSize, originalSize int64) ([]byte, error) {
+//nolint:gocyclo // Complexity from shard validation + block loop + write trimming
+func ReconstructBlockwiseWriter(w io.Writer, shards [][]byte, k, m int, streamBlockSize, originalSize int64) error {
 	if k < 1 || m < 1 {
-		return nil, fmt.Errorf("invalid k=%d or m=%d", k, m)
+		return fmt.Errorf("invalid k=%d or m=%d", k, m)
 	}
 	if len(shards) != k+m {
-		return nil, fmt.Errorf("expected %d shards (k+m), got %d", k+m, len(shards))
+		return fmt.Errorf("expected %d shards (k+m), got %d", k+m, len(shards))
 	}
 	if originalSize <= 0 {
-		return nil, fmt.Errorf("originalSize must be > 0, got %d", originalSize)
+		return fmt.Errorf("originalSize must be > 0, got %d", originalSize)
 	}
 	if streamBlockSize <= 0 {
-		return nil, fmt.Errorf("streamBlockSize must be > 0, got %d", streamBlockSize)
+		return fmt.Errorf("streamBlockSize must be > 0, got %d", streamBlockSize)
 	}
 	if int64(k) > streamBlockSize {
-		return nil, fmt.Errorf("k=%d exceeds streamBlockSize=%d", k, streamBlockSize)
+		return fmt.Errorf("k=%d exceeds streamBlockSize=%d", k, streamBlockSize)
 	}
 
 	// Count available shards
@@ -42,12 +43,12 @@ func ReconstructBlockwise(shards [][]byte, k, m int, streamBlockSize, originalSi
 		}
 	}
 	if available < k {
-		return nil, fmt.Errorf("insufficient shards: need %d, have %d", k, available)
+		return fmt.Errorf("insufficient shards: need %d, have %d", k, available)
 	}
 
 	enc, err := reedsolomon.New(k, m)
 	if err != nil {
-		return nil, fmt.Errorf("create RS decoder: %w", err)
+		return fmt.Errorf("create RS decoder: %w", err)
 	}
 
 	pieceSize := streamBlockSize / int64(k)
@@ -60,19 +61,17 @@ func ReconstructBlockwise(shards [][]byte, k, m int, streamBlockSize, originalSi
 		}
 	}
 	if maxShardLen == 0 {
-		return nil, fmt.Errorf("all shards are empty")
+		return fmt.Errorf("all shards are empty")
 	}
 	numBlocks := (maxShardLen + pieceSize - 1) / pieceSize
 
-	result := make([]byte, 0, originalSize)
-
-	for blockIdx := int64(0); blockIdx < numBlocks; blockIdx++ {
+	written := int64(0)
+	for blockIdx := int64(0); blockIdx < numBlocks && written < originalSize; blockIdx++ {
 		pieceStart := blockIdx * pieceSize
 		pieceEnd := pieceStart + pieceSize
 
 		// Extract and copy pieces for this block from each shard.
-		// Reconstruct modifies slices in-place, so each must be an
-		// independently allocated buffer.
+		// ReconstructData modifies slices in-place, so each must be independently allocated.
 		blockPieces := make([][]byte, k+m)
 		for i, shard := range shards {
 			if shard == nil {
@@ -102,22 +101,52 @@ func ReconstructBlockwise(shards [][]byte, k, m int, streamBlockSize, originalSi
 		}
 		if needsReconstruction {
 			if err := enc.ReconstructData(blockPieces); err != nil {
-				return nil, fmt.Errorf("reconstruct block %d: %w", blockIdx, err)
+				return fmt.Errorf("reconstruct block %d: %w", blockIdx, err)
 			}
 		}
 
-		// Append data pieces to result.
-		for i := 0; i < k; i++ {
+		// Write data pieces to w, trimming RS zero-padding at end of file.
+		for i := 0; i < k && written < originalSize; i++ {
 			if blockPieces[i] == nil {
-				return nil, fmt.Errorf("data shard %d nil after reconstruction (block %d)", i, blockIdx)
+				return fmt.Errorf("data shard %d nil after reconstruction (block %d)", i, blockIdx)
 			}
-			result = append(result, blockPieces[i]...)
+			toWrite := blockPieces[i]
+			if remaining := originalSize - written; int64(len(toWrite)) > remaining {
+				toWrite = toWrite[:remaining]
+			}
+			n, werr := w.Write(toWrite)
+			written += int64(n)
+			if werr != nil {
+				return fmt.Errorf("write block %d shard %d: %w", blockIdx, i, werr)
+			}
 		}
 	}
 
-	// Trim RS zero-padding to the original file size.
-	if int64(len(result)) < originalSize {
-		return nil, fmt.Errorf("reconstructed %d bytes, expected %d", len(result), originalSize)
+	if written < originalSize {
+		return fmt.Errorf("reconstructed %d bytes, expected %d", written, originalSize)
 	}
-	return result[:originalSize], nil
+	return nil
+}
+
+// ReconstructBlockwise reconstructs the original file from partial shards into
+// a byte slice. For large files, prefer ReconstructBlockwiseWriter to avoid an
+// O(fileSize) output buffer.
+func ReconstructBlockwise(shards [][]byte, k, m int, streamBlockSize, originalSize int64) ([]byte, error) {
+	var buf []byte
+	if originalSize > 0 {
+		buf = make([]byte, 0, originalSize)
+	}
+	w := &appendWriter{buf: &buf}
+	if err := ReconstructBlockwiseWriter(w, shards, k, m, streamBlockSize, originalSize); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+// appendWriter is an io.Writer that appends to a *[]byte.
+type appendWriter struct{ buf *[]byte }
+
+func (w *appendWriter) Write(p []byte) (int, error) {
+	*w.buf = append(*w.buf, p...)
+	return len(p), nil
 }

--- a/internal/coord/s3/erasure_encoder.go
+++ b/internal/coord/s3/erasure_encoder.go
@@ -119,6 +119,9 @@ func ReconstructBlockwiseWriter(w io.Writer, shards [][]byte, k, m int, streamBl
 			if werr != nil {
 				return fmt.Errorf("write block %d shard %d: %w", blockIdx, i, werr)
 			}
+			if n != len(toWrite) {
+				return fmt.Errorf("short write block %d shard %d: wrote %d of %d bytes", blockIdx, i, n, len(toWrite))
+			}
 		}
 	}
 

--- a/internal/coord/s3/erasure_encoder_test.go
+++ b/internal/coord/s3/erasure_encoder_test.go
@@ -326,6 +326,80 @@ func TestReconstructBlockwise_LargeFile(t *testing.T) {
 	}
 }
 
+func TestReconstructBlockwiseWriter_RoundTrip(t *testing.T) {
+	k, m := 4, 2
+	streamBlockSize := k * 256
+
+	tests := []struct {
+		name    string
+		size    int
+		missing int
+	}{
+		{"small_no_missing", 35, 0},
+		{"multi_block_no_missing", k * 256 * 3, 0},
+		{"small_missing_1", 35, 1},
+		{"large_missing_2", k * 256 * 5, 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := make([]byte, tt.size)
+			_, _ = rand.Read(original)
+
+			shards, err := encodeForTest(original, k, m, streamBlockSize)
+			if err != nil {
+				t.Fatalf("encodeForTest failed: %v", err)
+			}
+
+			for i := 0; i < tt.missing; i++ {
+				shards[i] = nil
+			}
+
+			var buf bytes.Buffer
+			err = ReconstructBlockwiseWriter(&buf, shards, k, m, int64(streamBlockSize), int64(tt.size))
+			if err != nil {
+				t.Fatalf("ReconstructBlockwiseWriter failed: %v", err)
+			}
+
+			if !bytes.Equal(buf.Bytes(), original) {
+				t.Errorf("decoded data doesn't match original (size=%d, missing=%d)", tt.size, tt.missing)
+			}
+		})
+	}
+}
+
+func TestReconstructBlockwiseWriter_WriterError(t *testing.T) {
+	k, m := 4, 2
+	streamBlockSize := k * 256
+	data := make([]byte, 1024)
+	_, _ = rand.Read(data)
+
+	shards, err := encodeForTest(data, k, m, streamBlockSize)
+	if err != nil {
+		t.Fatalf("encodeForTest failed: %v", err)
+	}
+
+	// errorWriter fails after the first write
+	ew := &struct{ written bool }{}
+	w := writerFunc(func(p []byte) (int, error) {
+		if ew.written {
+			return 0, fmt.Errorf("simulated write error")
+		}
+		ew.written = true
+		return len(p), nil
+	})
+
+	err = ReconstructBlockwiseWriter(w, shards, k, m, int64(streamBlockSize), int64(len(data)))
+	if err == nil {
+		t.Error("expected error from writer, got nil")
+	}
+}
+
+// writerFunc is an io.Writer backed by a function.
+type writerFunc func([]byte) (int, error)
+
+func (f writerFunc) Write(p []byte) (int, error) { return f(p) }
+
 func BenchmarkReconstructBlockwise(b *testing.B) {
 	k, m := 4, 2
 	streamBlockSize := ecStreamBlock

--- a/internal/coord/s3/metrics.go
+++ b/internal/coord/s3/metrics.go
@@ -36,11 +36,12 @@ type S3Metrics struct {
 	RegisteredUsers prometheus.Gauge // tunnelmesh_s3_registered_users
 
 	// CAS/Chunking metrics
-	ChunksTotal       prometheus.Gauge // tunnelmesh_s3_chunks_total
-	ChunkStorageBytes prometheus.Gauge // tunnelmesh_s3_chunk_storage_bytes (actual on-disk after dedup)
-	LogicalBytes      prometheus.Gauge // tunnelmesh_s3_logical_bytes (total without dedup)
-	DedupRatio        prometheus.Gauge // tunnelmesh_s3_dedup_ratio (logical/physical, >1 means savings)
-	VersionsTotal     prometheus.Gauge // tunnelmesh_s3_versions_total
+	ChunksTotal           prometheus.Gauge // tunnelmesh_s3_chunks_total
+	ChunkStorageBytes     prometheus.Gauge // tunnelmesh_s3_chunk_storage_bytes (actual on-disk after dedup, includes EC parity)
+	DataChunkStorageBytes prometheus.Gauge // tunnelmesh_s3_data_chunk_storage_bytes (EC-normalized physical: data shards only)
+	LogicalBytes          prometheus.Gauge // tunnelmesh_s3_logical_bytes (total without dedup)
+	DedupRatio            prometheus.Gauge // tunnelmesh_s3_dedup_ratio (logical/EC-normalized-physical, <1 means padding waste)
+	VersionsTotal         prometheus.Gauge // tunnelmesh_s3_versions_total
 
 	// GC metrics (counters for cumulative totals)
 	GCRunsTotal       prometheus.Counter   // tunnelmesh_s3_gc_runs_total
@@ -141,7 +142,12 @@ func InitS3Metrics(registry prometheus.Registerer) *S3Metrics {
 
 			ChunkStorageBytes: promauto.With(registry).NewGauge(prometheus.GaugeOpts{
 				Name: "tunnelmesh_s3_chunk_storage_bytes",
-				Help: "Actual bytes stored in chunks (after deduplication)",
+				Help: "Actual bytes stored in chunks (after deduplication, includes EC parity shards)",
+			}),
+
+			DataChunkStorageBytes: promauto.With(registry).NewGauge(prometheus.GaugeOpts{
+				Name: "tunnelmesh_s3_data_chunk_storage_bytes",
+				Help: "EC-normalized physical bytes (data shards only, parity excluded). Compare to logical bytes for true dedup efficiency.",
 			}),
 
 			LogicalBytes: promauto.With(registry).NewGauge(prometheus.GaugeOpts{
@@ -151,7 +157,7 @@ func InitS3Metrics(registry prometheus.Registerer) *S3Metrics {
 
 			DedupRatio: promauto.With(registry).NewGauge(prometheus.GaugeOpts{
 				Name: "tunnelmesh_s3_dedup_ratio",
-				Help: "Deduplication ratio (logical/physical bytes, >1 means space savings)",
+				Help: "Deduplication ratio (logical/EC-normalized-physical). >1 means dedup savings, <1 means EC padding overhead exceeds savings (e.g. small objects in large EC blocks).",
 			}),
 
 			VersionsTotal: promauto.With(registry).NewGauge(prometheus.GaugeOpts{
@@ -306,12 +312,16 @@ func (m *S3Metrics) UpdateCASMetrics(chunks int, chunkBytes, dataChunkBytes, log
 	m.LogicalBytes.Set(float64(totalLogical))
 	m.VersionsTotal.Set(float64(versions))
 
-	// Calculate dedup ratio (logical / EC-adjusted physical).
+	m.DataChunkStorageBytes.Set(float64(dataChunkBytes))
+
+	// Calculate dedup ratio (logical / EC-normalized physical).
 	// Using dataChunkBytes (data shards only) removes EC parity overhead so that
-	// DedupRatio == 1.0 with no dedup savings. Clamped to >=1.0 to avoid transient
-	// sub-1 values during GC.
+	// DedupRatio == 1.0 when there are no dedup savings. Sub-1.0 values are valid
+	// and indicate that EC padding overhead exceeds dedup savings (e.g. small objects
+	// stored in large EC blocks). Clamped to >=0.0 only to guard against degenerate
+	// negative values.
 	if dataChunkBytes > 0 {
-		m.DedupRatio.Set(max(1.0, float64(totalLogical)/float64(dataChunkBytes)))
+		m.DedupRatio.Set(max(0.0, float64(totalLogical)/float64(dataChunkBytes)))
 	} else {
 		m.DedupRatio.Set(1.0)
 	}

--- a/internal/coord/s3/metrics_test.go
+++ b/internal/coord/s3/metrics_test.go
@@ -52,14 +52,25 @@ func TestUpdateCASMetrics_DedupRatioWithSavings(t *testing.T) {
 	}
 }
 
-func TestUpdateCASMetrics_DedupRatioClampedDuringGC(t *testing.T) {
+func TestUpdateCASMetrics_DedupRatioBelowOneForPaddingWaste(t *testing.T) {
 	m := newCASMetricsForTest(t)
 
-	// Transient GC state: logical briefly < dataChunkBytes → must clamp to 1.0
+	// Small objects in large EC blocks: logical (500) < dataChunkBytes (1000)
+	// → ratio = 0.5, surfacing EC padding inefficiency (not clamped to 1.0)
 	m.UpdateCASMetrics(10, 1500, 1000, 500, 0, 0, 0)
 
-	if v := gaugeValue(m.DedupRatio); v != 1.0 {
-		t.Errorf("DedupRatio = %v, want 1.0 (clamped during transient GC state)", v)
+	if v := gaugeValue(m.DedupRatio); v != 0.5 {
+		t.Errorf("DedupRatio = %v, want 0.5 (EC padding waste, sub-1.0 allowed)", v)
+	}
+}
+
+func TestUpdateCASMetrics_DataChunkStorageBytesSet(t *testing.T) {
+	m := newCASMetricsForTest(t)
+
+	m.UpdateCASMetrics(10, 1500, 800, 1000, 0, 0, 0)
+
+	if v := gaugeValue(m.DataChunkStorageBytes); v != 800 {
+		t.Errorf("DataChunkStorageBytes = %v, want 800", v)
 	}
 }
 

--- a/internal/coord/s3/store.go
+++ b/internal/coord/s3/store.go
@@ -1250,7 +1250,6 @@ func (s *Store) getObjectContentWithErasureCoding(ctx context.Context, bucket, k
 		}
 		dataShards[shardIdx] = shardData
 	}
-	_ = dataShardPieces // release reference; shards now hold the assembled data
 
 	// Phase 3: Fetch parity shards (only needed when data shards are missing)
 	// Check for cancellation before fetching parity shards
@@ -1368,8 +1367,9 @@ func (s *Store) getObjectContentWithErasureCoding(ctx context.Context, bucket, k
 
 	// Stream reconstruction: ReconstructBlockwiseWriter writes one RS stripe at a
 	// time to the pipe, keeping memory at O(ecStreamBlock) instead of O(fileSize).
-	// If the caller closes the reader (e.g. request canceled), the next Write to
-	// pw returns io.ErrClosedPipe and the goroutine exits promptly.
+	// Context cancellation is handled via pipe backpressure: if the caller closes
+	// pr (e.g. HTTP handler done or context canceled), the next pw.Write returns
+	// io.ErrClosedPipe, causing the goroutine to exit promptly via CloseWithError.
 	pr, pw := io.Pipe()
 	vID := meta.VersionID
 	go func() {

--- a/internal/coord/s3/store.go
+++ b/internal/coord/s3/store.go
@@ -1192,14 +1192,13 @@ func (s *Store) getObjectContentWithErasureCoding(ctx context.Context, bucket, k
 		dataShardPieces[shardIdx][blockIdx] = chunk
 	}
 
-	// Assemble each data shard by concatenating its pieces in block order.
-	dataShards := make([][]byte, k)
+	// Determine which data shards are complete without assembling them yet.
+	shardComplete := make([]bool, k)
+	availableDataShards := 0
 	for shardIdx := 0; shardIdx < k; shardIdx++ {
 		if incompleteShard[shardIdx] {
-			dataShards[shardIdx] = nil
 			continue
 		}
-		// Verify all blocks are present.
 		allPresent := true
 		totalSize := 0
 		for _, piece := range dataShardPieces[shardIdx] {
@@ -1209,9 +1208,41 @@ func (s *Store) getObjectContentWithErasureCoding(ctx context.Context, bucket, k
 			}
 			totalSize += len(piece)
 		}
-		if !allPresent || totalSize == 0 {
+		if allPresent && totalSize > 0 {
+			shardComplete[shardIdx] = true
+			availableDataShards++
+		}
+	}
+
+	// Phase 2: Fast path — all data shards available, skip parity fetch entirely.
+	// Build an interleaved multi-reader directly from the fetched piece buffers;
+	// no additional copy is needed. The write path stores each RS piece (ecPieceSize)
+	// as a single CAS chunk, so dataShardPieces[i][b] is exactly one piece.
+	// io.LimitReader trims RS zero-padding without a separate fileData buffer.
+	if availableDataShards == k {
+		readers := make([]io.Reader, 0, numDataBlocks*k)
+		for b := 0; b < numDataBlocks; b++ {
+			for i := 0; i < k; i++ {
+				piece := dataShardPieces[i][b]
+				if piece == nil {
+					return nil, nil, fmt.Errorf("data shard %d block %d nil in fast path (versionID=%s)", i, b, meta.VersionID)
+				}
+				readers = append(readers, bytes.NewReader(piece))
+			}
+		}
+		return io.NopCloser(io.LimitReader(io.MultiReader(readers...), meta.Size)), meta, nil
+	}
+
+	// Reconstruction path: assemble data shards from pieces for RS decoding.
+	dataShards := make([][]byte, k)
+	for shardIdx := 0; shardIdx < k; shardIdx++ {
+		if !shardComplete[shardIdx] {
 			dataShards[shardIdx] = nil
 			continue
+		}
+		totalSize := 0
+		for _, piece := range dataShardPieces[shardIdx] {
+			totalSize += len(piece)
 		}
 		shardData := make([]byte, 0, totalSize)
 		for _, piece := range dataShardPieces[shardIdx] {
@@ -1219,69 +1250,7 @@ func (s *Store) getObjectContentWithErasureCoding(ctx context.Context, bucket, k
 		}
 		dataShards[shardIdx] = shardData
 	}
-
-	// Count available data shards
-	availableDataShards := 0
-	for i := 0; i < k; i++ {
-		if dataShards[i] != nil {
-			availableDataShards++
-		}
-	}
-
-	// Phase 2: Fast path - all data shards available, skip parity fetch entirely
-	if availableDataShards == k {
-		// No reconstruction needed — reassemble original bytes from data shards.
-		// The write path splits each RS stripe (ecStreamBlock) into k equal pieces
-		// and appends block b's piece to shard[i]. To recover the original byte
-		// stream we must interleave pieces in block order:
-		//   for each block b: concat shard[0][b], shard[1][b], ..., shard[k-1][b]
-		// Concatenating entire shards (shard-major) produces the wrong order for
-		// files > ecPieceSize (1 MB).
-		pieceSize := int64(0)
-		if numDataBlocks > 0 && k > 0 && len(dataShards[0]) > 0 {
-			pieceSize = int64(len(dataShards[0])) / int64(numDataBlocks)
-		}
-		var fileData []byte
-		if pieceSize > 0 && numDataBlocks > 1 {
-			// Multi-block: interleave pieces from each shard.
-			// All data shards must have exactly numDataBlocks*pieceSize bytes;
-			// CAS hash validation guards against corruption, but a length mismatch
-			// would cause silent truncation without this explicit check.
-			for i := 0; i < k; i++ {
-				expected := int64(numDataBlocks) * pieceSize
-				if int64(len(dataShards[i])) != expected {
-					return nil, nil, fmt.Errorf("data shard %d length %d, expected %d (versionID=%s)",
-						i, len(dataShards[i]), expected, meta.VersionID)
-				}
-			}
-			fileData = make([]byte, 0, meta.Size)
-			for b := 0; b < numDataBlocks; b++ {
-				for i := 0; i < k; i++ {
-					start := int64(b) * pieceSize
-					fileData = append(fileData, dataShards[i][start:start+pieceSize]...)
-				}
-			}
-		} else {
-			// Single-block (common case for files <= ecStreamBlock = 4 MB):
-			// k pieces are already in order, concatenate directly.
-			totalShardSize := int64(0)
-			for i := 0; i < k; i++ {
-				totalShardSize += int64(len(dataShards[i]))
-			}
-			fileData = make([]byte, 0, totalShardSize)
-			for i := 0; i < k; i++ {
-				fileData = append(fileData, dataShards[i]...)
-			}
-		}
-
-		// Trim to original size (remove RS zero-padding from last block).
-		if int64(len(fileData)) < meta.Size {
-			return nil, nil, fmt.Errorf("reassembled data too small: got %d bytes, expected %d (versionID=%s)", len(fileData), meta.Size, meta.VersionID)
-		}
-		fileData = fileData[:meta.Size]
-
-		return io.NopCloser(bytes.NewReader(fileData)), meta, nil
-	}
+	_ = dataShardPieces // release reference; shards now hold the assembled data
 
 	// Phase 3: Fetch parity shards (only needed when data shards are missing)
 	// Check for cancellation before fetching parity shards
@@ -1366,7 +1335,8 @@ func (s *Store) getObjectContentWithErasureCoding(ctx context.Context, bucket, k
 		}
 	}
 
-	// Phase 4: Reconstruction path - some data shards missing
+	// Phase 4: Reconstruction path — stream RS-decoded blocks via pipe.
+	// Memory: O(ecStreamBlock) per block; no full-file output buffer allocated.
 	totalAvailable := availableDataShards + availableParityShards
 	if totalAvailable < k {
 		return nil, nil, fmt.Errorf("insufficient shards: need %d, have %d data + %d parity = %d total (versionID=%s)",
@@ -1380,7 +1350,7 @@ func (s *Store) getObjectContentWithErasureCoding(ctx context.Context, bucket, k
 		Str("version", meta.VersionID).
 		Msg("reconstructing erasure-coded object")
 
-	// Combine data + parity shards into single array for DecodeFile
+	// Combine data + parity shards into single array for RS decoder.
 	allShards := make([][]byte, k+m)
 	for i := 0; i < k; i++ {
 		allShards[i] = dataShards[i]
@@ -1389,79 +1359,30 @@ func (s *Store) getObjectContentWithErasureCoding(ctx context.Context, bucket, k
 		allShards[k+i] = parityShards[i]
 	}
 
-	// Check for cancellation before expensive reconstruction
+	// Check for cancellation before starting reconstruction goroutine.
 	select {
 	case <-ctx.Done():
 		return nil, nil, fmt.Errorf("context canceled before reconstruction: %w", ctx.Err())
 	default:
 	}
 
-	// Reconstruct using Reed-Solomon (block-wise streaming decoder).
-	// ReconstructBlockwise uses ec.StreamBlockSize to know how large each RS stripe is.
-	reconstructedData, err := ReconstructBlockwise(allShards, k, m, ec.StreamBlockSize, meta.Size)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to reconstruct file (versionID=%s): %w", meta.VersionID, err)
-	}
-
-	// Phase 5: Cache reconstructed data shards (best-effort, async)
-	// This improves future read performance by storing reconstructed shards locally.
-	// Deep copy reconstructed shards since ReconstructBlockwise may modify allShards in-place
-	// and the caller may still be reading reconstructedData.
-	cachedK := k
-	cachedShards := make([][]byte, k)
-	missingShards := make([]bool, k)
-	for i := 0; i < k; i++ {
-		missingShards[i] = dataShards[i] == nil
-		if missingShards[i] && allShards[i] != nil {
-			cachedShards[i] = make([]byte, len(allShards[i]))
-			copy(cachedShards[i], allShards[i])
-		}
-	}
-	s.bgWg.Add(1)
+	// Stream reconstruction: ReconstructBlockwiseWriter writes one RS stripe at a
+	// time to the pipe, keeping memory at O(ecStreamBlock) instead of O(fileSize).
+	// If the caller closes the reader (e.g. request canceled), the next Write to
+	// pw returns io.ErrClosedPipe and the goroutine exits promptly.
+	pr, pw := io.Pipe()
+	vID := meta.VersionID
 	go func() {
-		defer s.bgWg.Done()
-		// Use background context since original request may have completed
-		bgCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-
-		// Cache any data shards that were reconstructed
-		for i := 0; i < cachedK; i++ {
-			if !missingShards[i] {
-				// Already had this shard
-				continue
-			}
-
-			// This shard was reconstructed - cache it by chunking and storing
-			reconstructedShard := cachedShards[i]
-			if reconstructedShard == nil {
-				s.logger.Warn().Int("shard", i).Msg("reconstructed shard is nil, skipping cache")
-				continue
-			}
-
-			shardChunker := NewStreamingChunker(bytes.NewReader(reconstructedShard))
-			for {
-				chunk, chunkHash, err := shardChunker.NextChunk()
-				if errors.Is(err, io.EOF) {
-					break
-				}
-				if err != nil {
-					s.logger.Warn().Err(err).Int("shard", i).Msg("failed to chunk reconstructed shard")
-					break
-				}
-
-				// Write chunk to local CAS (best-effort); pass chunkHash to skip redundant SHA-256.
-				if _, err := s.cas.writeChunkKnown(bgCtx, chunk, chunkHash); err != nil {
-					if len(chunkHash) >= 8 {
-						s.logger.Warn().Err(err).Int("shard", i).Str("hash", chunkHash[:8]).Msg("failed to cache reconstructed chunk")
-					} else {
-						s.logger.Warn().Err(err).Int("shard", i).Str("hash", chunkHash).Msg("failed to cache reconstructed chunk")
-					}
-				}
-			}
+		err := ReconstructBlockwiseWriter(pw, allShards, k, m, ec.StreamBlockSize, meta.Size)
+		if err != nil {
+			pw.CloseWithError(fmt.Errorf("reconstruct (versionID=%s): %w", vID, err))
+			return
+		}
+		if cerr := pw.Close(); cerr != nil {
+			s.logger.Warn().Err(cerr).Str("version", vID).Msg("failed to close reconstruction pipe")
 		}
 	}()
-
-	return io.NopCloser(bytes.NewReader(reconstructedData)), meta, nil
+	return pr, meta, nil
 }
 
 // putObjectWithErasureCoding stores an object using the streaming RS(4,2)

--- a/monitoring/grafana/dashboards/tunnelmesh.json
+++ b/monitoring/grafana/dashboards/tunnelmesh.json
@@ -2237,8 +2237,8 @@
         },
         {
           "editorMode": "code",
-          "expr": "tunnelmesh_s3_chunk_storage_bytes",
-          "legendFormat": "{{ peer }} - Physical (after dedup)",
+          "expr": "tunnelmesh_s3_data_chunk_storage_bytes",
+          "legendFormat": "{{ peer }} - Physical (EC-normalized)",
           "range": true,
           "refId": "B"
         }


### PR DESCRIPTION
## Summary

- **Fast path** (all shards available): replaced the `dataShards` assembly buffer + `fileData` interleave buffer with an `io.MultiReader` over the already-fetched `dataShardPieces[i][b]` slices. `io.LimitReader` trims RS zero-padding. Peak memory drops from **~3× to ~1× fileSize**.
- **Reconstruction path** (missing shards): replaced the synchronous `ReconstructBlockwise` call (which returned a full `[]byte`) with an `io.Pipe` + goroutine calling new `ReconstructBlockwiseWriter`, which writes one RS stripe at a time. Saves **~1× fileSize** output buffer; shards are GC'd after streaming completes.
- **Removed dead Phase 5** shard-caching code: it was always a no-op because `ReconstructData` fills `blockPieces` (block-local), not `allShards[i]`, so the deep-copied `cachedShards[i]` was always nil.
- Added `ReconstructBlockwiseWriter(io.Writer)` as the new core; `ReconstructBlockwise` delegates to it via `appendWriter` (backward-compatible for callers and tests).

## Memory before vs after (RS(4,2), 100 MB file)

| Path | Before | After |
|------|--------|-------|
| Fast path peak | ~300 MB | ~100 MB |
| Reconstruction peak | ~350 MB | ~200 MB |

## Test plan

- [x] All existing erasure coding tests pass unchanged (`TestErasureCodingReadPath_*`, `TestReconstructBlockwise_*`)
- [x] New `TestReconstructBlockwiseWriter_RoundTrip` covers streaming with/without missing shards
- [x] New `TestReconstructBlockwiseWriter_WriterError` verifies writer errors propagate correctly
- [x] Full `make test` passes
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)