### PR TITLE
docs(mesh): add internal/mesh doc.go (#329)

### DIFF
--- a/internal/mesh/constants.go
+++ b/internal/mesh/constants.go
@@ -1,4 +1,3 @@
-// Package mesh provides constants for the TunnelMesh network configuration.
 package mesh
 
 const (

--- a/internal/mesh/doc.go
+++ b/internal/mesh/doc.go
@@ -1,0 +1,12 @@
+// Package mesh provides constants and helpers for TunnelMesh domain suffixes.
+//
+// TunnelMesh peers resolve names under several suffixes (.tunnelmesh, .tm, .mesh)
+// within the mesh network. Use IsValidSuffix to accept client-provided suffixes
+// and AllSuffixes when enumerating supported values.
+//
+// Example:
+//
+//	if mesh.IsValidSuffix(".mesh") {
+//	    suffixes := mesh.AllSuffixes()
+//	}
+package mesh


### PR DESCRIPTION
## Summary
- Add `internal/mesh/doc.go` with package overview and usage example
- Remove redundant package comment from `constants.go`

## Test plan
- [x] `go test ./internal/mesh/...`

Part of #329 (mesh package)